### PR TITLE
[Fix] markdown links pointing to correct location

### DIFF
--- a/docs/examples/custom-secrets/README.md
+++ b/docs/examples/custom-secrets/README.md
@@ -1,14 +1,14 @@
-# Local Secrets Monitoring
+# Custom Secrets Monitoring
 
-If you have local secrets you wish to monitor, the examples in this directory will help you achieve that.
+If you have custom secrets you wish to monitor (you created them as k8s resources), the examples in this directory will help you achieve that.
 
 ## Service Definition
 
-There is a service defined in [service.yaml](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/local-secrets/service.yaml) to allow you to scrape the exporter from prometheus with the config in [prometheus-scrape.yaml](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/local-secrets/prometheus-scrape.yaml).  The prometheus config assumes you are using the [prometheus-operator helm chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator)
+There is a service defined in [service.yaml](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/custom-secrets/service.yaml) to allow you to scrape the exporter from prometheus with the config in [prometheus-scrape.yaml](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/custom-secrets/prometheus-scrape.yaml).  The prometheus config assumes you are using the [prometheus-operator helm chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator)
 
 ## Secret Creation
 
-On [line 27 of the deployment file](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/local-secrets/deployment.yaml#27) you will see the additional options passed to the cert exporter that allows for monitoring certificates based on labels.  In order for your certs to be monitored, the certificate keys all need to end in `*.crt` (unless you override that option with --secrets-data-glob).  The [example secret](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/local-secrets/secret.yaml) is configured to be monitored by prometheus.
+On [line 27 of the deployment file](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/custom-secrets/deployment.yaml#L27) you will see the additional options passed to the cert exporter that allows for monitoring certificates based on labels.  In order for your certs to be monitored, the certificate keys all need to end in `*.crt` (unless you override that option with --secrets-data-glob).  The [example secret](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/custom-secrets/secret.yaml) is configured to be monitored by prometheus.
 
 **NOTE:  The label only has to have a matching key.  Any value supplied will work!**
 
@@ -22,4 +22,4 @@ By default, the certificate dashboard monitors for `cert_exporter_cert_expires_i
 
 There could be a number of things wrong, but [this helpful flowchart](https://learnk8s.io/a/troubleshooting-kubernetes.pdf) will help to get you sorted.
 
-You can also `exec` into a pod running in your cluster and try to curl the metrics endpoint of the `cert-exporter` by running `curl cert-exporter:8080/metrics` and see what you get back.
+You can also `exec` into a pod running in your cluster and try to curl the metrics endpoint of the `cert-exporter` by running `curl cert-exporter:8080/metrics` and see what you get back. (`cert-exporter` hostname assumes that is the name you have used in [service.yaml](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/custom-secrets/service.yaml))

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ cert-exporter can publish metrics about
 
 See [deployment](https://github.com/joe-elliott/cert-exporter/blob/master/docs/deploy.md) for detailed information on running cert-exporter and examples of running it in a [kops](https://github.com/kubernetes/kops) cluster.
 
-See [custom-secrets](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/custom-secrets) for examples of how to run it to scrape certificates in secrets managed by you (not cert-manager).
+See [custom-secrets](https://github.com/joe-elliott/cert-exporter/blob/master/docs/examples/custom-secrets) for examples of how to run `cert-exporter` to scrape certificates in secrets managed by you (not cert-manager).
 
 ### Dashboard
 


### PR DESCRIPTION
My apologies--my last PR was missing a commit where I fixed the links in the markdown to point to the new folder name (originally was using local-secrets and decided on custom-secrets instead).

These links all work now, sorry about that!