### PR TITLE
[Fix] match namespaces in binding to svcacct

### DIFF
--- a/docs/examples/custom-secrets/clusterrolebinding.yaml
+++ b/docs/examples/custom-secrets/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: cert-exporter
-  namespace: default
+  namespace: monitoring
 roleRef:
   kind: ClusterRole
   name: secret-reader


### PR DESCRIPTION
Fixing mistake in example files that break permissions.