### PR TITLE
Expose certificates' node name

### DIFF
--- a/docs/daemonset-prom-operator.yaml
+++ b/docs/daemonset-prom-operator.yaml
@@ -26,6 +26,11 @@ spec:
         - --include-kubeconfig-glob=/var/lib/*/kubeconfig
         - --include-cert-glob=/srv/kubernetes/*.crt
         - --alsologtostderr
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
         - mountPath: /var/lib/kubelet
           name: kubelet

--- a/docs/kops-masters.yaml
+++ b/docs/kops-masters.yaml
@@ -36,6 +36,11 @@ spec:
         - --include-cert-glob=/srv/kubernetes/*.crt
         - --include-cert-glob=/srv/kubernetes/*.cert
         - --alsologtostderr
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
         - mountPath: /var/lib/kubelet
           name: kubelet

--- a/docs/kops-nodes.yaml
+++ b/docs/kops-nodes.yaml
@@ -24,6 +24,11 @@ spec:
         - --include-kubeconfig-glob=/var/lib/*/kubeconfig
         - --include-cert-glob=/srv/kubernetes/*.crt
         - --alsologtostderr
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
         - mountPath: /var/lib/kubelet
           name: kubelet

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,22 +8,22 @@ Example:
 # ./test.sh
 ** Testing Certs and kubeconfig in the same dir
 cert_exporter_error_total 0
-TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certs/client.crt"}
-TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certs/root.crt"}
-TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certs/server.crt"}
-TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="cluster1",type="cluster"}
-TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="cluster2",type="cluster"}
-TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="user1",type="user"}
-TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="user2",type="user"}
+TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certs/client.crt",issuer="root",nodename="master0"}
+TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certs/root.crt",issuer="root",nodename="master0"}
+TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certs/server.crt",issuer="root",nodename="master0"}
+TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="cluster1",nodename="master0",type="cluster"}
+TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="cluster2",nodename="master0",type="cluster"}
+TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="user1",nodename="master0",type="user"}
+TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="user2",nodename="master0",type="user"}
 ** Testing Certs and kubeconfig in sibling dirs
 cert_exporter_error_total 0
-TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certsSibling/client.crt"}
-TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certsSibling/root.crt"}
-TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certsSibling/server.crt"}
-TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="cluster1",type="cluster"}
-TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="cluster2",type="cluster"}
-TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="user1",type="user"}
-TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="user2",type="user"}
+TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certsSibling/client.crt",issuer="root",nodename="master0"}
+TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certsSibling/root.crt",issuer="root",nodename="master0"}
+TEST SUCCESS: cert_exporter_cert_expires_in_seconds{filename="certsSibling/server.crt",issuer="root",nodename="master0"}
+TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="cluster1",nodename="master0",type="cluster"}
+TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="cluster2",nodename="master0",type="cluster"}
+TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="user1",nodename="master0",type="user"}
+TEST SUCCESS: cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="user2",nodename="master0",type="user"}
 ** Testing Error metric increments
 E0707 09:25:59.470115   56712 periodicCertChecker.go:47] Error on certs/client.crt: Failed to parse as a pem
 cert_exporter_error_total 1

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/joe-elliott/cert-exporter/src/args"
@@ -53,12 +54,12 @@ func main() {
 	glog.Info("Application Starting")
 
 	if len(includeCertGlobs) > 0 {
-		certChecker := checkers.NewCertChecker(pollingPeriod, includeCertGlobs, excludeCertGlobs, &exporters.CertExporter{})
+		certChecker := checkers.NewCertChecker(pollingPeriod, includeCertGlobs, excludeCertGlobs, os.Getenv("NODE_NAME"), &exporters.CertExporter{})
 		go certChecker.StartChecking()
 	}
 
 	if len(includeKubeConfigGlobs) > 0 {
-		configChecker := checkers.NewCertChecker(pollingPeriod, includeKubeConfigGlobs, excludeKubeConfigGlobs, &exporters.KubeConfigExporter{})
+		configChecker := checkers.NewCertChecker(pollingPeriod, includeKubeConfigGlobs, excludeKubeConfigGlobs, os.Getenv("NODE_NAME"), &exporters.KubeConfigExporter{})
 		go configChecker.StartChecking()
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # cert-exporter
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![version](https://img.shields.io/badge/version-1.4.0-blue.svg?cacheSeconds=2592000)
+[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![version](https://img.shields.io/badge/version-2.0.0-blue.svg?cacheSeconds=2592000)
 
 Kubernetes uses PKI certificates for authentication between all major components.  These certs are critical for the operation of your cluster but are often opaque to an administrator.  This application is designed to parse certificates and export expiration information for Prometheus to scrape.
 

--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,10 @@ cert_exporter_secret_expires_in_seconds{key_name="tls.crt",secret_name="selfsign
 The total number of unexpected errors encountered by cert-exporter.  A good metric to watch to feel comfortable certs are being exported properly.
 
 **cert_exporter_cert_expires_in_seconds**  
-The number of seconds until a certificate stored in the PEM format is expired.  The `filename` label indicates the exported cert.
+The number of seconds until a certificate stored in the PEM format is expired.  The `filename`, `issuer`, `cn`, and `nodename` label indicates the exported cert.
 
 **cert_exporter_kubeconfig_expires_in_seconds**  
-The number of seconds until a certificate stored in a kubeconfig expires.  The `filename`, `type`, and `name` labels indicate the kubeconfig, cluster or user node and name of the node.  See details [here](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
+The number of seconds until a certificate stored in a kubeconfig expires.  The `filename`, `type`, `name`, and `nodename` labels indicate the kubeconfig, cluster or user node and name of the node.  See details [here](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
 
 **cert_exporter_secret_expires_in_seconds**
 The number of seconds until a certificate stored in a kubernetes secret expires.  The `key_name`, `secret_name`, and `secret_namespace` labels indicate the secret key, name and namespace. 

--- a/src/checkers/periodicCertChecker.go
+++ b/src/checkers/periodicCertChecker.go
@@ -14,15 +14,17 @@ type PeriodicCertChecker struct {
 	period           time.Duration
 	includeCertGlobs []string
 	excludeCertGlobs []string
+	nodeName         string
 	exporter         exporters.Exporter
 }
 
 // NewCertChecker is a factory method that returns a new PeriodicCertChecker
-func NewCertChecker(period time.Duration, includeCertGlobs []string, excludeCertGlobs []string, e exporters.Exporter) *PeriodicCertChecker {
+func NewCertChecker(period time.Duration, includeCertGlobs, excludeCertGlobs []string, nodeName string, e exporters.Exporter) *PeriodicCertChecker {
 	return &PeriodicCertChecker{
 		period:           period,
 		includeCertGlobs: includeCertGlobs,
 		excludeCertGlobs: excludeCertGlobs,
+		nodeName:         nodeName,
 		exporter:         e,
 	}
 }
@@ -43,7 +45,7 @@ func (p *PeriodicCertChecker) StartChecking() {
 
 			glog.Infof("Publishing metrics for %v", match)
 
-			err := p.exporter.ExportMetrics(match)
+			err := p.exporter.ExportMetrics(match, p.nodeName)
 
 			if err != nil {
 				metrics.ErrorTotal.Inc()

--- a/src/exporters/certExporter.go
+++ b/src/exporters/certExporter.go
@@ -9,7 +9,7 @@ type CertExporter struct {
 }
 
 // ExportMetrics exports the provided PEM file
-func (c *CertExporter) ExportMetrics(file string) error {
+func (c *CertExporter) ExportMetrics(file, nodeName string) error {
 
 	metric, err := secondsToExpiryFromCertAsFile(file)
 
@@ -17,7 +17,7 @@ func (c *CertExporter) ExportMetrics(file string) error {
 		return err
 	}
 
-	metrics.CertExpirySeconds.WithLabelValues(file, metric.issuer, metric.cn).Set(metric.durationUntilExpiry)
-	metrics.CertNotAfterTimestamp.WithLabelValues(file, metric.issuer, metric.cn).Set(metric.notAfter)
+	metrics.CertExpirySeconds.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.durationUntilExpiry)
+	metrics.CertNotAfterTimestamp.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.notAfter)
 	return nil
 }

--- a/src/exporters/exporter.go
+++ b/src/exporters/exporter.go
@@ -2,5 +2,5 @@ package exporters
 
 // Exporter is an interface for objects that export cert information
 type Exporter interface {
-	ExportMetrics(file string) error
+	ExportMetrics(file, nodeName string) error
 }

--- a/src/exporters/kubeConfigExporter.go
+++ b/src/exporters/kubeConfigExporter.go
@@ -13,7 +13,7 @@ type KubeConfigExporter struct {
 }
 
 // ExportMetrics exports all certs in the passed in kubeconfig file
-func (c *KubeConfigExporter) ExportMetrics(file string) error {
+func (c *KubeConfigExporter) ExportMetrics(file, nodeName string) error {
 	k, err := kubeconfig.ParseKubeConfig(file)
 
 	if err != nil {
@@ -40,8 +40,8 @@ func (c *KubeConfigExporter) ExportMetrics(file string) error {
 			return fmt.Errorf("Cluster %v does not have CertAuthority or CertAuthorityData", c.Name)
 		}
 
-		metrics.KubeConfigExpirySeconds.WithLabelValues(file, "cluster", c.Name).Set(metric.durationUntilExpiry)
-		metrics.KubeConfigNotAfterTimestamp.WithLabelValues(file, "cluster", c.Name).Set(metric.notAfter)
+		metrics.KubeConfigExpirySeconds.WithLabelValues(file, "cluster", c.Name, nodeName).Set(metric.durationUntilExpiry)
+		metrics.KubeConfigNotAfterTimestamp.WithLabelValues(file, "cluster", c.Name, nodeName).Set(metric.notAfter)
 	}
 
 	for _, u := range k.Users {
@@ -64,8 +64,8 @@ func (c *KubeConfigExporter) ExportMetrics(file string) error {
 			return fmt.Errorf("User %v does not have ClientCert or ClientCertData", u.Name)
 		}
 
-		metrics.KubeConfigExpirySeconds.WithLabelValues(file, "user", u.Name).Set(metric.durationUntilExpiry)
-		metrics.KubeConfigNotAfterTimestamp.WithLabelValues(file, "user", u.Name).Set(metric.notAfter)
+		metrics.KubeConfigExpirySeconds.WithLabelValues(file, "user", u.Name, nodeName).Set(metric.durationUntilExpiry)
+		metrics.KubeConfigNotAfterTimestamp.WithLabelValues(file, "user", u.Name, nodeName).Set(metric.notAfter)
 	}
 
 	return nil

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -23,7 +23,7 @@ var (
 			Name:      "cert_expires_in_seconds",
 			Help:      "Number of seconds til the cert expires.",
 		},
-		[]string{"filename", "issuer", "cn"},
+		[]string{"filename", "issuer", "cn", "nodename"},
 	)
 
 	// CertNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
@@ -33,7 +33,7 @@ var (
 			Name:      "cert_not_after_timestamp",
 			Help:      "Timestamp of when the certificate expires.",
 		},
-		[]string{"filename", "issuer", "cn"},
+		[]string{"filename", "issuer", "cn", "nodename"},
 	)
 
 	// KubeConfigExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubeconfig certificate expires.
@@ -43,7 +43,7 @@ var (
 			Name:      "kubeconfig_expires_in_seconds",
 			Help:      "Number of seconds til the cert in the kubeconfig expires.",
 		},
-		[]string{"filename", "type", "name"},
+		[]string{"filename", "type", "name", "nodename"},
 	)
 
 	// KubeConfigNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
@@ -53,7 +53,7 @@ var (
 			Name:      "kubeconfig_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the kubeconfig.",
 		},
-		[]string{"filename", "type", "name"},
+		[]string{"filename", "type", "name", "nodename"},
 	)
 
 	// SecretExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubernetes secret certificate expires

--- a/test/files/test.sh
+++ b/test/files/test.sh
@@ -32,6 +32,7 @@ go build ../../main.go
 chmod +x main
 
 days=${1:-100}
+NODE_NAME="master0"
 
 #
 # certs and kubeconfig in the same dir
@@ -48,14 +49,14 @@ sleep 2
 
 curl --silent http://localhost:8080/metrics | grep 'cert_exporter_error_total 0'
 
-validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="client",filename="certs/client.crt",issuer="root"}' $days
-validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="root",filename="certs/root.crt",issuer="root"}' $days
-validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="example.com",filename="certs/server.crt",issuer="root"}' $days
+validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="client",filename="certs/client.crt",issuer="root",nodename="master0"}' $days
+validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="root",filename="certs/root.crt",issuer="root",nodename="master0"}' $days
+validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="example.com",filename="certs/server.crt",issuer="root",nodename="master0"}' $days
 
-validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="cluster1",type="cluster"}' $days
-validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="cluster2",type="cluster"}' $days
-validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="user1",type="user"}' $days
-validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="user2",type="user"}' $days
+validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="cluster1",nodename="master0",type="cluster"}' $days
+validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="cluster2",nodename="master0",type="cluster"}' $days
+validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="user1",nodename="master0",type="user"}' $days
+validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="certs/kubeconfig",name="user2",nodename="master0",type="user"}' $days
 
 # kill exporter
 kill $!
@@ -76,14 +77,14 @@ sleep 2
 
 curl --silent http://localhost:8080/metrics | grep 'cert_exporter_error_total 0'
 
-validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="client",filename="certsSibling/client.crt",issuer="root"}' $days
-validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="root",filename="certsSibling/root.crt",issuer="root"}' $days
-validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="example.com",filename="certsSibling/server.crt",issuer="root"}' $days
+validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="client",filename="certsSibling/client.crt",issuer="root",nodename="master0"}' $days
+validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="root",filename="certsSibling/root.crt",issuer="root",nodename="master0"}' $days
+validateMetrics 'cert_exporter_cert_expires_in_seconds{cn="example.com",filename="certsSibling/server.crt",issuer="root",nodename="master0"}' $days
 
-validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="cluster1",type="cluster"}' $days
-validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="cluster2",type="cluster"}' $days
-validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="user1",type="user"}' $days
-validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="user2",type="user"}' $days
+validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="cluster1",nodename="master0",type="cluster"}' $days
+validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="cluster2",nodename="master0",type="cluster"}' $days
+validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="user1",nodename="master0",type="user"}' $days
+validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="user2",nodename="master0",type="user"}' $days
 
 # kill exporter
 kill $!


### PR DESCRIPTION
The Kubernetes HA setup (multiple master nodes), the Kubernetes/ETCD certificates and also Kubeconfig exist on all master nodes.

For better UX monitoring experience, it's better to expose the certificates' belongs to which nodes information to the user.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>