### PR TITLE
Migrate from k3d to kind cluster

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ The number of seconds until a certificate stored in a kubernetes secret expires.
 ### Other Docs
 
 - [Testing](https://github.com/joe-elliott/cert-exporter/blob/master/docs/testing.md)
-  - An overview of the testing scripts and how to run them.
+  - An overview of the testing scripts and how to run them. It requires [kind](https://github.com/kubernetes-sigs/kind) CLI.
 - [Deployment](https://github.com/joe-elliott/cert-exporter/blob/master/docs/deploy.md)
   - Information on how to deploy cert-exporter as well as examples for a kops cluster.
 - [Daemonset for Prometheus-operator](https://github.com/joe-elliott/cert-exporter/blob/master/docs/daemonset-prom-operator.md)

--- a/test/cert-manager-v1alpha1/test.sh
+++ b/test/cert-manager-v1alpha1/test.sh
@@ -1,7 +1,7 @@
 #
 # requires a k8s cluster running with cert-manager running in it
-#  assumes the location of kubeconfig at ~/.kube/config
-# requires k3d
+#  assumes the location of kubeconfig at $HOME/.kube/config
+# requires kind https://github.com/kubernetes-sigs/kind
 #
 
 validateMetrics() {
@@ -30,61 +30,51 @@ validateMetrics() {
     fi
 }
 
-export KUBECONFIG=""
-K3D_NAME=cert-exporter
-CONFIG_PATH="k3d get-kubeconfig --name=$K3D_NAME"
+KIND_CLUSTER_NAME=cert-exporter
 
-k3d create --name=$K3D_NAME
-echo -n "Ensuring k3d is running..."
-while true; do
-  k3d list 2>&1 | grep ".*$K3D_NAME.*running" >/dev/null && echo "done" && break \
-    || (echo -n . && sleep 1)
-done
+echo -n "Create cluster"
+kind create cluster --name=$KIND_CLUSTER_NAME
 
-echo -n "Getting kubeconfig..."
-while true; do
-  eval $CONFIG_PATH 2>&1 | grep "$K3D_NAME/kubeconfig.yaml" >/dev/null && echo done && break \
-    || (echo -n . && sleep 1)
-done
-echo Config is available at $(eval $CONFIG_PATH)
+echo -n "Get kubeconfig"
+kind export kubeconfig --name=$KIND_CLUSTER_NAME
 
-kubectl --kubeconfig $(eval $CONFIG_PATH) create namespace cert-manager
-kubectl --kubeconfig $(eval $CONFIG_PATH) label namespace cert-manager certmanager.k8s.io/disable-validation=true
-kubectl --kubeconfig $(eval $CONFIG_PATH) apply -f https://github.com/jetstack/cert-manager/releases/download/v0.10.1/cert-manager.yaml
+kubectl --kubeconfig=$HOME/.kube/config create namespace cert-manager
+kubectl --kubeconfig=$HOME/.kube/config label namespace cert-manager certmanager.k8s.io/disable-validation=true
+kubectl --kubeconfig=$HOME/.kube/config apply -f https://github.com/jetstack/cert-manager/releases/download/v0.10.1/cert-manager.yaml
 
-sleep 180
+kubectl --kubeconfig=$HOME/.kube/config wait --for=condition=available deploy --all -n cert-manager --timeout=3m
 
-kubectl --kubeconfig $(eval $CONFIG_PATH) create -f ./certs.yaml
-
+GO111MODULE=on go mod vendor
 go build ../../main.go
-chmod +x ./main
+
+kubectl --kubeconfig=$HOME/.kube/config create -f ./certs.yaml
+
+kubectl --kubeconfig=$HOME/.kube/config wait --for=condition=ready certificate/selfsigned-cert -n cert-manager-test
 
 echo "** Testing Label Selector"
 # run exporter
-./main --kubeconfig $(eval $CONFIG_PATH) \
-               --secrets-label-selector 'certmanager.k8s.io/certificate-name' \
-               --secrets-include-glob='*.crt' \
-               --alsologtostderr &
+./main --kubeconfig=$HOME/.kube/config \
+    --secrets-label-selector='certmanager.k8s.io/certificate-name' \
+    --secrets-include-glob='*.crt' \
+    --alsologtostderr &
 pid=$!
-sleep 5
+sleep 10
 
 validateMetrics 'cert_exporter_secret_expires_in_seconds{cn="example.com",issuer="example.com",key_name="ca.crt",secret_name="selfsigned-cert-tls",secret_namespace="cert-manager-test"}' 100
 
 # kill exporter
 echo "** Killing $pid"
 kill $pid
-
-sleep 5
 
 echo "** Testing Label Selector And Namespace"
 # run exporter
-./main --kubeconfig $(eval $CONFIG_PATH) \
-               --secrets-label-selector 'certmanager.k8s.io/certificate-name' \
-               --secrets-namespace 'cert-manager-test' \
-               --secrets-include-glob='*.crt' \
-               --alsologtostderr &
+./main --kubeconfig=$HOME/.kube/config \
+    --secrets-label-selector='certmanager.k8s.io/certificate-name' \
+    --secrets-namespace='cert-manager-test' \
+    --secrets-include-glob='*.crt' \
+    --alsologtostderr &
 pid=$!
-sleep 5
+sleep 10
 
 validateMetrics 'cert_exporter_secret_expires_in_seconds{cn="example.com",issuer="example.com",key_name="ca.crt",secret_name="selfsigned-cert-tls",secret_namespace="cert-manager-test"}' 100
 
@@ -92,8 +82,5 @@ validateMetrics 'cert_exporter_secret_expires_in_seconds{cn="example.com",issuer
 echo "** Killing $pid"
 kill $pid
 
-read -p "press enter"
-
 rm ./main
-kubectl --kubeconfig $(eval $CONFIG_PATH) delete -f ./certs.yaml
-k3d delete --name=$K3D_NAME
+kind delete cluster --name=$KIND_CLUSTER_NAME

--- a/test/files/test.sh
+++ b/test/files/test.sh
@@ -28,8 +28,8 @@ validateMetrics() {
 ./testCleanup.sh
 
 # build
+GO111MODULE=on go mod vendor
 go build ../../main.go
-chmod +x main
 
 days=${1:-100}
 export NODE_NAME="master0"


### PR DESCRIPTION
[kind](https://github.com/kubernetes-sigs/kind) is a good tool for development testing and easy to bootstrap a cluster within a docker container.

Migrates the testing script from k3d cluster to kind cluster.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>