### PR TITLE
Exposes subject's O & OU & SAN

### DIFF
--- a/src/exporters/certExporter.go
+++ b/src/exporters/certExporter.go
@@ -15,7 +15,7 @@ func (c *CertExporter) ExportMetrics(file, nodeName string) error {
 		return err
 	}
 
-	metrics.CertExpirySeconds.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.durationUntilExpiry)
-	metrics.CertNotAfterTimestamp.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.notAfter)
+	metrics.CertExpirySeconds.WithLabelValues(file, metric.cn, metric.subject, metric.subjectSAN, metric.issuer, nodeName).Set(metric.durationUntilExpiry)
+	metrics.CertNotAfterTimestamp.WithLabelValues(file, metric.cn, metric.subject, metric.subjectSAN, metric.issuer, nodeName).Set(metric.notAfter)
 	return nil
 }

--- a/src/exporters/secretExporter.go
+++ b/src/exporters/secretExporter.go
@@ -15,7 +15,7 @@ func (c *SecretExporter) ExportMetrics(bytes []byte, keyName, secretName, secret
 		return err
 	}
 
-	metrics.SecretExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.durationUntilExpiry)
-	metrics.SecretNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.notAfter)
+	metrics.SecretExpirySeconds.WithLabelValues(keyName, metric.cn, metric.subject, metric.subjectSAN, metric.issuer, secretName, secretNamespace).Set(metric.durationUntilExpiry)
+	metrics.SecretNotAfterTimestamp.WithLabelValues(keyName, metric.cn, metric.subject, metric.subjectSAN, metric.issuer, secretName, secretNamespace).Set(metric.notAfter)
 	return nil
 }

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -23,7 +23,7 @@ var (
 			Name:      "cert_expires_in_seconds",
 			Help:      "Number of seconds til the cert expires.",
 		},
-		[]string{"filename", "issuer", "cn", "nodename"},
+		[]string{"filename", "cn", "cert", "cert_SAN", "issuer", "nodename"},
 	)
 
 	// CertNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
@@ -33,7 +33,7 @@ var (
 			Name:      "cert_not_after_timestamp",
 			Help:      "Timestamp of when the certificate expires.",
 		},
-		[]string{"filename", "issuer", "cn", "nodename"},
+		[]string{"filename", "cn", "cert", "cert_SAN", "issuer", "nodename"},
 	)
 
 	// KubeConfigExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubeconfig certificate expires.
@@ -63,7 +63,7 @@ var (
 			Name:      "secret_expires_in_seconds",
 			Help:      "Number of seconds til the cert in the secret expires.",
 		},
-		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
+		[]string{"key_name", "cn", "cert", "cert_SAN", "issuer", "secret_name", "secret_namespace"},
 	)
 
 	// SecretNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
@@ -73,7 +73,7 @@ var (
 			Name:      "secret_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the secret.",
 		},
-		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
+		[]string{"key_name", "cn", "cert", "cert_SAN", "issuer", "secret_name", "secret_namespace"},
 	)
 )
 


### PR DESCRIPTION
According to RFC, if SAN exists, then the validator must check it first and CN should not be checked.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>