### PR TITLE
Add github action for CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go ^1.12
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.12
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Test cert-manager-v1alpha1
+        run: |
+          cd test/cert-manager-v1alpha1
+          ./test.sh
+
+      - name: Test cert-manager-v1alpha2
+        run: |
+          cd test/cert-manager-v1alpha2
+          ./test.sh
+
+      - name: Test certificate and kubeconfig
+        run: |
+          cd test/files
+          ./test.sh

--- a/test/cert-manager-v1alpha1/test.sh
+++ b/test/cert-manager-v1alpha1/test.sh
@@ -1,7 +1,9 @@
-#
+#!/bin/bash
+
 # requires a k8s cluster running with cert-manager running in it
 # requires kind https://github.com/kubernetes-sigs/kind
-#
+
+set -o errexit
 
 validateMetrics() {
     metrics=$1
@@ -33,7 +35,8 @@ KIND_CLUSTER_NAME=cert-exporter
 CONFIG_PATH=cert-exporter.kubeconfig
 
 echo -n "Create cluster"
-kind create cluster --name=$KIND_CLUSTER_NAME --kubeconfig=$CONFIG_PATH
+# cert-manager v1alpha1 is no longer workable on kubernetes version >= v1.18.x
+kind create cluster --name=$KIND_CLUSTER_NAME --kubeconfig=$CONFIG_PATH --image=kindest/node:v1.17.0
 
 kubectl --kubeconfig=$CONFIG_PATH create namespace cert-manager
 kubectl --kubeconfig=$CONFIG_PATH label namespace cert-manager certmanager.k8s.io/disable-validation=true

--- a/test/cert-manager-v1alpha2/test.sh
+++ b/test/cert-manager-v1alpha2/test.sh
@@ -1,7 +1,9 @@
-#
+#!/bin/bash
+
 # requires a k8s cluster running with cert-manager running in it
 # requires kind https://github.com/kubernetes-sigs/kind
-#
+
+set -o errexit
 
 validateMetrics() {
     metrics=$1

--- a/test/files/test.sh
+++ b/test/files/test.sh
@@ -1,3 +1,10 @@
+#!/bin/bash
+
+# requires a k8s cluster running with cert-manager running in it
+# requires kind https://github.com/kubernetes-sigs/kind
+
+set -o errexit
+
 validateMetrics() {
     metrics=$1
     expectedVal=$2    


### PR DESCRIPTION
note that fix cert-manager-v1alpha1 test on k8s v1.17.0 cluster
since the yaml manifest is no longer workable on k8s >= v1.18.x cluster

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>