### PR TITLE
Reference a specific alpine version for the release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN go mod download && \
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:latest 
+FROM alpine:3.12
 
 RUN addgroup -g 1000 app && \
     adduser -u 1000 -h /app -G app -S app


### PR DESCRIPTION
It is a best practice to reference a specific image tag instead of the latest tag as 3, 4 months down the road, what does latest mean? It is hard to say. This way we will know exactly what version of alpine that was used to build the release image.

My company also uses security scanning tools, both static analysis during our builds and during runtime in the cluster and the current release (2.3.0) was displaying a security vulnerability. [CVE-2020-1967](https://nvd.nist.gov/vuln/detail/CVE-2020-1967) to be exact. It is marked as a high severity, so it is definitely something we want to take care of before deploying to production.