### PR TITLE
Changed all examples to do use logtostderr

### DIFF
--- a/docs/cert-manager.yaml
+++ b/docs/cert-manager.yaml
@@ -24,7 +24,7 @@ spec:
         args:
         - --secrets-annotation-selector=cert-manager.io/certificate-name
         - --secrets-include-glob=*.crt
-        - --alsologtostderr
+        - --logtostderr
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/docs/daemonset-prom-operator.yaml
+++ b/docs/daemonset-prom-operator.yaml
@@ -25,7 +25,7 @@ spec:
         args:
         - --include-kubeconfig-glob=/var/lib/*/kubeconfig
         - --include-cert-glob=/srv/kubernetes/*.crt
-        - --alsologtostderr
+        - --logtostderr
         env:
         - name: NODE_NAME
           valueFrom:

--- a/docs/examples/custom-secrets/deployment.yaml
+++ b/docs/examples/custom-secrets/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         command: ["./app"]
         args:
         - --secrets-label-selector=monitor-cert
-        - --alsologtostderr
+        - --logtostderr
         ports:
           - name: metrics
             containerPort: 8080

--- a/docs/kops-masters.yaml
+++ b/docs/kops-masters.yaml
@@ -35,7 +35,7 @@ spec:
         - --include-cert-glob=/etc/kubernetes/pki/*/*.crt
         - --include-cert-glob=/srv/kubernetes/*.crt
         - --include-cert-glob=/srv/kubernetes/*.cert
-        - --alsologtostderr
+        - --logtostderr
         env:
         - name: NODE_NAME
           valueFrom:

--- a/docs/kops-nodes.yaml
+++ b/docs/kops-nodes.yaml
@@ -23,7 +23,7 @@ spec:
         args:
         - --include-kubeconfig-glob=/var/lib/*/kubeconfig
         - --include-cert-glob=/srv/kubernetes/*.crt
-        - --alsologtostderr
+        - --logtostderr
         env:
         - name: NODE_NAME
           valueFrom:

--- a/test/cert-manager-v1alpha1/test.sh
+++ b/test/cert-manager-v1alpha1/test.sh
@@ -56,7 +56,7 @@ echo "** Testing Label Selector"
 ./main --kubeconfig=$CONFIG_PATH \
     --secrets-label-selector='certmanager.k8s.io/certificate-name' \
     --secrets-include-glob='*.crt' \
-    --alsologtostderr &
+    --logtostderr &
 pid=$!
 sleep 10
 
@@ -72,7 +72,7 @@ echo "** Testing Label Selector And Namespace"
     --secrets-label-selector='certmanager.k8s.io/certificate-name' \
     --secrets-namespace='cert-manager-test' \
     --secrets-include-glob='*.crt' \
-    --alsologtostderr &
+    --logtostderr &
 pid=$!
 sleep 10
 

--- a/test/cert-manager-v1alpha2/test.sh
+++ b/test/cert-manager-v1alpha2/test.sh
@@ -59,7 +59,7 @@ echo "** Testing Label Selector"
     --secrets-annotation-selector='cert-manager.io/certificate-name' \
     --secrets-annotation-selector='test' \
     --secrets-include-glob='*.crt' \
-    --alsologtostderr &
+    --logtostderr &
 pid=$!
 sleep 10
 
@@ -76,7 +76,7 @@ echo "** Testing Label Selector And Namespace"
     --secrets-annotation-selector='cert-manager.io/certificate-name' \
     --secrets-namespace='cert-manager-test' \
     --secrets-include-glob='*.crt' \
-    --alsologtostderr &
+    --logtostderr &
 pid=$!
 sleep 10
 
@@ -92,7 +92,7 @@ echo "** Testing Label Selector And Exclude Glob"
     --secrets-annotation-selector='cert-manager.io/certificate-name' \
     --secrets-namespace='cert-manager-test' \
     --secrets-exclude-glob='*.key' \
-    --alsologtostderr &
+    --logtostderr &
 pid=$!
 sleep 10
 


### PR DESCRIPTION
Now that I understand glog better I wish I had used a different logger :).  Switching to logtostderr so cert-exporter leaves the host disk alone.