### PR TITLE
Added || true to prevent a missed grep from silently failing the test

### DIFF
--- a/test/cert-manager-v1alpha1/test.sh
+++ b/test/cert-manager-v1alpha1/test.sh
@@ -9,7 +9,7 @@ validateMetrics() {
     metrics=$1
     expectedVal=$2    
 
-    raw=$(curl --silent http://localhost:8080/metrics | grep "$metrics")
+    raw=$(curl --silent http://localhost:8080/metrics | grep "$metrics" || true)
 
     if [ "$raw" == "" ]; then
       echo "TEST FAILURE: $metrics" 

--- a/test/cert-manager-v1alpha2/test.sh
+++ b/test/cert-manager-v1alpha2/test.sh
@@ -9,7 +9,7 @@ validateMetrics() {
     metrics=$1
     expectedVal=$2    
 
-    raw=$(curl --silent http://localhost:8080/metrics | grep "$metrics")
+    raw=$(curl --silent http://localhost:8080/metrics | grep "$metrics" || true)
 
     if [ "$raw" == "" ]; then
       echo "TEST FAILURE: $metrics" 


### PR DESCRIPTION
This issue was revealed by discussions in #42.  The change will prevent a missed metric from silently failing the test script.