### PR TITLE
chore: add check count metric for secrets

### DIFF
--- a/src/exporters/secretExporter.go
+++ b/src/exporters/secretExporter.go
@@ -17,5 +17,6 @@ func (c *SecretExporter) ExportMetrics(bytes []byte, keyName, secretName, secret
 
 	metrics.SecretExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.durationUntilExpiry)
 	metrics.SecretNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.notAfter)
+	metrics.SecretCheckTotal.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Inc()
 	return nil
 }

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -66,6 +66,16 @@ var (
 		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
 	)
 
+	// SecretCheckTotal is a prometheus counter that indicates the total number of times a secret was found
+	SecretCheckTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "secret_check_total",
+			Help:      "Number of times a secret was found",
+		},
+		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
+	)
+
 	// SecretNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
 	SecretNotAfterTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -85,4 +95,5 @@ func init() {
 	prometheus.MustRegister(KubeConfigNotAfterTimestamp)
 	prometheus.MustRegister(SecretExpirySeconds)
 	prometheus.MustRegister(SecretNotAfterTimestamp)
+	prometheus.MustRegister(SecretCheckTotal)
 }


### PR DESCRIPTION
Trying to address https://github.com/joe-elliott/cert-exporter/issues/56, how to ensure alerts go away when you delete an expired certificate stored in a secret.

Assuming the pooling frequency is `15m` counting each time a certificate is checked, allows us to to alert on things like `(cert_exporter_secret_expires_in_seconds <= 604800) * (rate(cert_exporter_secret_check_total[30m]) > bool 0)` in other words - if the certificate expires soon _and_ it has been checked. 

Not sure if that's the best way, but it works on our local tests.