### PR TITLE
Sync build version with go mod version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as build
+FROM golang:1.14 as build
 WORKDIR /src
 
 COPY . .


### PR DESCRIPTION
https://github.com/joe-elliott/cert-exporter/blob/master/go.mod#L3 is 1.14 the build is using 1.12