### PR TITLE
add filtering by secret type

### DIFF
--- a/helm/cert-exporter/README.md
+++ b/helm/cert-exporter/README.md
@@ -7,7 +7,7 @@ Installs the project as a Deployment for monitoring cert-manager.
 ```
 helm repo add cert-exporter https://joe-elliott.github.io/cert-exporter/
 helm repo update
-helm install -n <my-namespace> cert-exporter/cert-exporter my-cert-exporter-release -f <values>
+helm install -n <my-namespace> my-cert-exporter-release  cert-exporter/cert-exporter -f <values>
 ```
 
 # Configuring the chart

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 	secretsNamespace          string
 	includeSecretsDataGlobs   args.GlobArgs
 	excludeSecretsDataGlobs   args.GlobArgs
+	includeSecretsTypes       args.GlobArgs
 )
 
 func init() {
@@ -51,6 +52,7 @@ func init() {
 	flag.Var(&secretsAnnotationSelector, "secrets-annotation-selector", "Annotation selector to find secrets to publish as metrics.")
 	flag.StringVar(&secretsNamespace, "secrets-namespace", "", "Kubernetes namespace to list secrets.")
 	flag.Var(&includeSecretsDataGlobs, "secrets-include-glob", "Secret globs to include when looking for secret data keys (Default \"*\").")
+	flag.Var(&includeSecretsTypes, "secret-include-types","Select only specific a type (Default nil).")
 	flag.Var(&excludeSecretsDataGlobs, "secrets-exclude-glob", "Secret globs to exclude when looking for secret data keys.")
 }
 
@@ -73,7 +75,7 @@ func main() {
 		if len(includeSecretsDataGlobs) == 0 {
 			includeSecretsDataGlobs = args.GlobArgs([]string{"*"})
 		}
-		configChecker := checkers.NewSecretChecker(pollingPeriod, secretsLabelSelector, includeSecretsDataGlobs, excludeSecretsDataGlobs, secretsAnnotationSelector, secretsNamespace, kubeconfigPath, &exporters.SecretExporter{})
+		configChecker := checkers.NewSecretChecker(pollingPeriod, secretsLabelSelector, includeSecretsDataGlobs, excludeSecretsDataGlobs, secretsAnnotationSelector, secretsNamespace, kubeconfigPath, &exporters.SecretExporter{}, includeSecretsTypes)
 		go configChecker.StartChecking()
 	}
 

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func init() {
 	flag.Var(&secretsAnnotationSelector, "secrets-annotation-selector", "Annotation selector to find secrets to publish as metrics.")
 	flag.StringVar(&secretsNamespace, "secrets-namespace", "", "Kubernetes namespace to list secrets.")
 	flag.Var(&includeSecretsDataGlobs, "secrets-include-glob", "Secret globs to include when looking for secret data keys (Default \"*\").")
-	flag.Var(&includeSecretsTypes, "secret-include-types","Select only specific a type (Default nil).")
+	flag.Var(&includeSecretsTypes, "secret-include-types", "Select only specific a type (Default nil).")
 	flag.Var(&excludeSecretsDataGlobs, "secrets-exclude-glob", "Secret globs to exclude when looking for secret data keys.")
 }
 

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func init() {
 	flag.Var(&secretsAnnotationSelector, "secrets-annotation-selector", "Annotation selector to find secrets to publish as metrics.")
 	flag.StringVar(&secretsNamespace, "secrets-namespace", "", "Kubernetes namespace to list secrets.")
 	flag.Var(&includeSecretsDataGlobs, "secrets-include-glob", "Secret globs to include when looking for secret data keys (Default \"*\").")
-	flag.Var(&includeSecretsTypes, "secret-include-types", "Select only specific a type (Default nil).")
+	flag.Var(&includeSecretsTypes, "secret-include-types", "Select only specific a secret type (Default nil).")
 	flag.Var(&excludeSecretsDataGlobs, "secrets-exclude-glob", "Secret globs to exclude when looking for secret data keys.")
 }
 

--- a/src/checkers/periodicSecretChecker.go
+++ b/src/checkers/periodicSecretChecker.go
@@ -101,7 +101,7 @@ func (p *PeriodicSecretChecker) StartChecking() {
 					}
 				}
 				if !include {
-					glog.Infof("Skipping secret %s in %s because %s is not included in your secret-include-types %v", secret.GetName(), secret.GetNamespace(), secret.Type, p.includeSecretsTypes)
+					glog.Infof("Ignoring secret %s in %s because %s is not included in your secret-include-types %v", secret.GetName(), secret.GetNamespace(), secret.Type, p.includeSecretsTypes)
 					continue
 				}
 			}

--- a/src/checkers/periodicSecretChecker.go
+++ b/src/checkers/periodicSecretChecker.go
@@ -92,12 +92,12 @@ func (p *PeriodicSecretChecker) StartChecking() {
 			// If you want only a certain type of cert
 			if len(p.includeSecretsTypes) > 0 {
 				exclude = false
-				for	_, t := range p.includeSecretsTypes {
+				for _, t := range p.includeSecretsTypes {
 					if string(secret.Type) == t {
 						include = true
 					}
 					if include {
-				       continue
+						continue
 					}
 				}
 				if !include {

--- a/src/checkers/periodicSecretChecker.go
+++ b/src/checkers/periodicSecretChecker.go
@@ -24,10 +24,11 @@ type PeriodicSecretChecker struct {
 	exporter                *exporters.SecretExporter
 	includeSecretsDataGlobs []string
 	excludeSecretsDataGlobs []string
+	includeSecretsTypes     []string
 }
 
 // NewSecretChecker is a factory method that returns a new PeriodicSecretChecker
-func NewSecretChecker(period time.Duration, labelSelectors, includeSecretsDataGlobs, excludeSecretsDataGlobs, annotationSelectors []string, namespace, kubeconfigPath string, e *exporters.SecretExporter) *PeriodicSecretChecker {
+func NewSecretChecker(period time.Duration, labelSelectors, includeSecretsDataGlobs, excludeSecretsDataGlobs, annotationSelectors []string, namespace, kubeconfigPath string, e *exporters.SecretExporter, includeSecretsTypes []string) *PeriodicSecretChecker {
 	return &PeriodicSecretChecker{
 		period:                  period,
 		labelSelectors:          labelSelectors,
@@ -37,6 +38,7 @@ func NewSecretChecker(period time.Duration, labelSelectors, includeSecretsDataGl
 		exporter:                e,
 		includeSecretsDataGlobs: includeSecretsDataGlobs,
 		excludeSecretsDataGlobs: excludeSecretsDataGlobs,
+		includeSecretsTypes:     includeSecretsTypes,
 	}
 }
 
@@ -86,6 +88,23 @@ func (p *PeriodicSecretChecker) StartChecking() {
 		}
 
 		for _, secret := range secrets {
+			include, exclude := false, false
+			// If you want only a certain type of cert
+			if len(p.includeSecretsTypes) > 0 {
+				exclude = false
+				for	_, t := range p.includeSecretsTypes {
+					if string(secret.Type) == t {
+						include = true
+					}
+					if include {
+				       continue
+					}
+				}
+				if !include {
+					continue
+				}
+			}
+
 			glog.Infof("Reviewing secret %v in %v", secret.GetName(), secret.GetNamespace())
 
 			if len(p.annotationSelectors) > 0 {
@@ -106,7 +125,7 @@ func (p *PeriodicSecretChecker) StartChecking() {
 			glog.Infof("Annotations matched. Parsing Secret.")
 
 			for name, bytes := range secret.Data {
-				include, exclude := false, false
+				include, exclude = false, false
 
 				for _, glob := range p.includeSecretsDataGlobs {
 					include, err = filepath.Match(glob, name)

--- a/src/checkers/periodicSecretChecker.go
+++ b/src/checkers/periodicSecretChecker.go
@@ -101,6 +101,7 @@ func (p *PeriodicSecretChecker) StartChecking() {
 					}
 				}
 				if !include {
+					glog.Infof("Skipping secret %s in %s because %s is not included in your secret-include-types %v", secret.GetName(), secret.GetNamespace(), secret.Type, p.includeSecretsTypes)
 					continue
 				}
 			}


### PR DESCRIPTION
- Fix helm example command
- added `secret-include-types=`

example use:
`./cert-exporter --secret-include-types=kubernetes.io/tls --secret-include-types=Opaque --secrets-include-glob=*crt*` 
The above would only gather tls secrets and opaque secrets and would no longer collect `kubernetes.io/service-account-token ` for example.  

Why is this useful? 
Some users are not able to modify tags for collection and do not want the "tokens" generated by other things. Forgive me if there is a better way to do this with the existing app but i couldn't think of one.

