### PR TITLE
Allow service annotations to be set in the Helm values

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 2.5.0
+version: 2.5.1
 appVersion: v2.5.0

--- a/helm/cert-exporter/templates/deployment/service.yaml
+++ b/helm/cert-exporter/templates/deployment/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "cert-exporter.fullname" . }}
   labels:
     {{ include "cert-exporter.certManagerDeploymentLabels" . | nindent 4 }}
+  {{- with .Values.certManagerDeployment.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.certManagerDeployment.service.type }}
   ports:

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -47,7 +47,10 @@ certManagerDeployment:
     port: 8080
 
     portName: http-metrics
-  
+
+    # Annotations to add to the service
+    annotations: {}
+
     # Requires prometheus-operator to be installed
     serviceMonitor:
       create: false
@@ -55,7 +58,7 @@ certManagerDeployment:
       # cannot be empty
       additionalLabels:
         prometheus.io/load-rule: "true"
-    
+
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       ##
       interval: 20s
@@ -97,7 +100,7 @@ rbac:
     - apiGroups: [""]
       resources: ["secrets"]
       verbs: ["get", "list"]
-  
+
   clusterRoleBinding:
     create: true
 


### PR DESCRIPTION
Fixes: https://github.com/joe-elliott/cert-exporter/issues/71

It templates OK when running "helm template" locally. Any concerns or changes you would like me to make please let me know.

Also thanks for cert exporter in general - really useful tool!

Many thanks!