### PR TITLE
Add possibility to helm chart to add pod annotations

### DIFF
--- a/helm/cert-exporter/templates/deployment/deployment.yaml
+++ b/helm/cert-exporter/templates/deployment/deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         {{- include "cert-exporter.certManagerDeploymentSelectorLabels" . | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.certManagerDeployment.deployment.podAnnotations | nindent 8 }}
     spec:
     {{- with .Values.certManagerDeployment.deployment.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -18,6 +18,12 @@ certManagerDeployment:
     nameOverride: ""
     fullnameOverride: ""
 
+    podAnnotations: {}
+    # environment: prod
+    # prometheus.io/scrape: true
+    # prometheus.io/port: 8080
+    # prometheus.io/path: /metrics
+
     podSecurityContext: {}
     # fsGroup: 2000
 


### PR DESCRIPTION
I would like to be able to add pod Annotations to the cert-exporter. I've added some examples what could be the need. I do have also the special need to add vault sidecar injector annotations. This allows me to retrieve certificates from vault and check their expire date.

I'm not so experienced in contributing to projects let me how I can help to merge this to master and release it :)