### PR TITLE
ability to add volumes and volumeMounts in helm chart

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 2.7.1
+version: 2.7.2
 appVersion: v2.7.0

--- a/helm/cert-exporter/templates/deployment/deployment.yaml
+++ b/helm/cert-exporter/templates/deployment/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.certManagerDeployment.deployment.resources | nindent 12 }}
+          volumeMounts:
+           {{- toYaml .Values.certManagerDeployment.deployment.volumeMounts | nindent 12 }}
       {{- with .Values.certManagerDeployment.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -55,3 +57,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      volumes:
+          {{- toYaml .Values.certManagerDeployment.deployment.volumes | nindent 8 }}

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -49,6 +49,16 @@ certManagerDeployment:
 
     affinity: {}
 
+    volumes: []
+      # - name: kubelet
+      #   hostPath:
+      #     path: /var/lib/kubelet
+      #     type: Directory
+    volumeMounts: []
+      # - mountPath: /var/lib/kubelet/pki
+      #   name: kubelet
+      #   readOnly: true
+
   service:
     type: ClusterIP
     port: 8080


### PR DESCRIPTION
I would like to be able to add an option to add volumes and volumeMounts to the helm chart. This can be useful for certs located on the disk.