### PR TITLE
fix(#90): certs expiration counts

### DIFF
--- a/docs/sample-dashboard-template.json
+++ b/docs/sample-dashboard-template.json
@@ -109,7 +109,7 @@
         "tableColumn": "",
         "targets": [
           {
-            "expr": "count(cert_exporter_cert_expires_in_seconds <= 15724800)+count(cert_exporter_kubeconfig_expires_in_seconds <= 15724800)+count(cert_exporter_secret_expires_in_seconds <= 15724800) OR on() vector(0)",
+            "expr": "(count(cert_exporter_cert_expires_in_seconds <= 15724800) OR on() vector(0)) + (count(cert_exporter_kubeconfig_expires_in_seconds <= 15724800) OR on() vector(0)) + (count(cert_exporter_secret_expires_in_seconds <= 15724800) OR on() vector(0))",
             "format": "time_series",
             "intervalFactor": 1,
             "refId": "A"
@@ -188,7 +188,7 @@
         "tableColumn": "",
         "targets": [
           {
-            "expr": "count(15724800 < cert_exporter_cert_expires_in_seconds and cert_exporter_cert_expires_in_seconds <= 31536000)+count(15724800 < cert_exporter_kubeconfig_expires_in_seconds and cert_exporter_kubeconfig_expires_in_seconds <= 31536000)+count(15724800 < cert_exporter_secret_expires_in_seconds and cert_exporter_secret_expires_in_seconds <= 31536000) OR on() vector(0)",
+            "expr": "(count(15724800 < cert_exporter_cert_expires_in_seconds and cert_exporter_cert_expires_in_seconds <= 31536000) OR on() vector(0)) + (count(15724800 < cert_exporter_kubeconfig_expires_in_seconds and cert_exporter_kubeconfig_expires_in_seconds <= 31536000) OR on() vector(0)) + (count(15724800 < cert_exporter_secret_expires_in_seconds and cert_exporter_secret_expires_in_seconds <= 31536000) OR on() vector(0))",
             "format": "time_series",
             "intervalFactor": 1,
             "refId": "A"
@@ -267,7 +267,7 @@
         "tableColumn": "",
         "targets": [
           {
-            "expr": "count(cert_exporter_cert_expires_in_seconds > 31536000)+count(cert_exporter_kubeconfig_expires_in_seconds > 31536000)+count(cert_exporter_secret_expires_in_seconds > 31536000) OR on() vector(0)",
+            "expr": "(count(cert_exporter_cert_expires_in_seconds > 31536000) OR on() vector(0)) + (count(cert_exporter_kubeconfig_expires_in_seconds > 31536000) OR on() vector(0)) + (count(cert_exporter_secret_expires_in_seconds > 31536000) OR on() vector(0))",
             "format": "time_series",
             "intervalFactor": 1,
             "refId": "A"

--- a/docs/sample-dashboard.json
+++ b/docs/sample-dashboard.json
@@ -74,7 +74,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(cert_exporter_cert_expires_in_seconds <= 15724800)+count(cert_exporter_kubeconfig_expires_in_seconds <= 15724800)+count(cert_exporter_secret_expires_in_seconds <= 15724800) OR on() vector(0)",
+          "expr": "(count(cert_exporter_cert_expires_in_seconds <= 15724800) OR on() vector(0)) + (count(cert_exporter_kubeconfig_expires_in_seconds <= 15724800) OR on() vector(0)) + (count(cert_exporter_secret_expires_in_seconds <= 15724800) OR on() vector(0))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -152,7 +152,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(15724800 < cert_exporter_cert_expires_in_seconds and cert_exporter_cert_expires_in_seconds <= 31536000)+count(15724800 < cert_exporter_kubeconfig_expires_in_seconds and cert_exporter_kubeconfig_expires_in_seconds <= 31536000)+count(15724800 < cert_exporter_secret_expires_in_seconds and cert_exporter_secret_expires_in_seconds <= 31536000) OR on() vector(0)",
+          "expr": "(count(15724800 < cert_exporter_cert_expires_in_seconds and cert_exporter_cert_expires_in_seconds <= 31536000) OR on() vector(0)) + (count(15724800 < cert_exporter_kubeconfig_expires_in_seconds and cert_exporter_kubeconfig_expires_in_seconds <= 31536000) OR on() vector(0)) + (count(15724800 < cert_exporter_secret_expires_in_seconds and cert_exporter_secret_expires_in_seconds <= 31536000) OR on() vector(0))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -230,7 +230,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(cert_exporter_cert_expires_in_seconds > 31536000)+count(cert_exporter_kubeconfig_expires_in_seconds > 31536000)+count(cert_exporter_secret_expires_in_seconds > 31536000) OR on() vector(0)",
+          "expr": "(count(cert_exporter_cert_expires_in_seconds > 31536000) OR on() vector(0)) + (count(cert_exporter_kubeconfig_expires_in_seconds > 31536000) OR on() vector(0)) + (count(cert_exporter_secret_expires_in_seconds > 31536000) OR on() vector(0))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"


### PR DESCRIPTION
As reported by @rajvml

I confirm I did experience with the same issue: when the cert-exporter is used to collect metrics exclusively from the kubernetes API, series such as cert_exporter_kubeconfig_expires_in_seconds are not defined, which breaks those expressions.

I've been using something similar to this fix for quite some time ( https://gitlab.com/synacksynack/opsperator/docker-operator/-/blob/master/roles/prometheus/files/dashboards/Cert_Manager.json ), should have submitted this a while ago ...
