### PR TITLE
fix(#88): adds mountPropagation=HostToContainer to /var/lib/kubelet

### DIFF
--- a/docs/daemonset-prom-operator.yaml
+++ b/docs/daemonset-prom-operator.yaml
@@ -33,6 +33,7 @@ spec:
               fieldPath: spec.nodeName
         volumeMounts:
         - mountPath: /var/lib/kubelet
+          mountPropagation: HostToContainer
           name: kubelet
           readOnly: true
         - mountPath: /var/lib/kube-proxy

--- a/docs/kops-masters.yaml
+++ b/docs/kops-masters.yaml
@@ -43,6 +43,7 @@ spec:
               fieldPath: spec.nodeName
         volumeMounts:
         - mountPath: /var/lib/kubelet
+          mountPropagation: HostToContainer
           name: kubelet
           readOnly: true
         - mountPath: /var/lib/kube-controller-manager

--- a/docs/kops-nodes.yaml
+++ b/docs/kops-nodes.yaml
@@ -31,6 +31,7 @@ spec:
               fieldPath: spec.nodeName
         volumeMounts:
         - mountPath: /var/lib/kubelet
+          mountPropagation: HostToContainer
           name: kubelet
           readOnly: true
         - mountPath: /var/lib/kube-proxy

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -56,6 +56,7 @@ certManagerDeployment:
       #     type: Directory
     volumeMounts: []
       # - mountPath: /var/lib/kubelet/pki
+      #   mountPropagation: HostToContainer
       #   name: kubelet
       #   readOnly: true
 


### PR DESCRIPTION
As reported by @FessAectan  (#88)
Adds mountPropagation option to volumeMounts involving /var/lib/kubelet