### PR TITLE
Add some values to the chart

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 2.7.4
+version: 2.8.0
 appVersion: v2.7.0

--- a/helm/cert-exporter/templates/deployment/deployment.yaml
+++ b/helm/cert-exporter/templates/deployment/deployment.yaml
@@ -13,6 +13,9 @@ spec:
     metadata:
       labels:
         {{- include "cert-exporter.certManagerDeploymentSelectorLabels" . | nindent 8 }}
+        {{- with .Values.certManagerDeployment.deployment.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- toYaml .Values.certManagerDeployment.deployment.podAnnotations | nindent 8 }}
     spec:
@@ -37,6 +40,9 @@ spec:
           args:
             {{- toYaml . | nindent 12}}
           {{- end}}
+          {{- with .Values.certManagerDeployment.deployment.env }}
+          env: {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm/cert-exporter/templates/deployment/servicemonitor.yaml
+++ b/helm/cert-exporter/templates/deployment/servicemonitor.yaml
@@ -27,4 +27,7 @@ spec:
     relabelings:
       {{ toYaml .Values.certManagerDeployment.service.serviceMonitor.relabelings | nindent 6 }}
     {{- end }}
+  {{- with .Values.certManagerDeployment.service.serviceMonitor.podTargetLabels }}
+  podTargetLabels: {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -18,8 +18,10 @@ certManagerDeployment:
     nameOverride: ""
     fullnameOverride: ""
 
-    podAnnotations: {}
+    podLabels: {}
     # environment: prod
+
+    podAnnotations: {}
     # prometheus.io/scrape: true
     # prometheus.io/port: 8080
     # prometheus.io/path: /metrics
@@ -42,6 +44,10 @@ certManagerDeployment:
       # requests:
       #   cpu: 100m
       #   memory: 128Mi
+
+    env: []
+    # - name: DEMO_GREETING
+    #   value: "Hello from the environment"  
 
     nodeSelector: {}
 
@@ -97,6 +103,12 @@ certManagerDeployment:
       #   targetLabel: nodename
       #   replacement: $1
       #   action: replace
+
+      ## PodTargetLabels transfers labels on the Kubernetes Pod onto the target. 
+      ##
+      podTargetLabels: []
+      # - app
+      # - environment
 
 rbac:
   serviceAccount:


### PR DESCRIPTION
Signed-off-by: Oliver Bähler <oliverbaehler@hotmail.com>

I have added some values to the chart which would help me deploy cert-exporter easier:

 * ` .Values.certManagerDeployment.deployment.podLabels `: Allows to add labels to the pod
 * `.Values.certManagerDeployment.deployment.env`: Allows to add env variables to the container
 * `.Values.certManagerDeployment.service.serviceMonitor.podTargetLabels`: Allows scraping of additional labels

Bumped version to `2.8.0`