### PR TITLE
Add ability to override image tag

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 3.0.0
+version: 3.0.1
 appVersion: v2.7.0

--- a/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
+++ b/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
@@ -30,7 +30,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.certManager.securityContext | nindent 12 }}
-          image: "{{ .Values.certManager.image.repository  }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.certManager.image.repository  }}:{{ .Values.certManager.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.certManager.image.pullPolicy }}
           {{- with .Values.certManager.image.command  }}
           command:

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -5,6 +5,8 @@ certManager:
 
   image:
     repository: joeelliott/cert-exporter
+    # The default tag is ".Chart.AppVersion", only set "tag" to override that
+    tag: 
     pullPolicy: IfNotPresent
     command: ["./app"]
     args:


### PR DESCRIPTION
This adds the ability to set a custom tag for the cert exporter docker image, but still defaults to the chart version if not set