### PR TITLE
fix: deploy go on new tag naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
-          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+          if [[ $GITHUB_REF =~ refs/tags/cert-exporter-[0-9].[0-9].[0-9] ]]; then
             make release
           else
             make release-snapshot


### PR DESCRIPTION
Go binaries have not been published since v2.6.x, this fixes the release package to run based on the new naming scheme used