### PR TITLE
chore: update build and base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 WORKDIR /src
 
 COPY . .
 RUN go mod download && \
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:3.15.0
+FROM alpine:3.16
 
 RUN addgroup -g 1000 app && \
     adduser -u 1000 -h /app -G app -S app


### PR DESCRIPTION
This will update the build image to go 1.18 and the alpine base image to the current 3.16.

Fixes #109. Might fix #110.