### PR TITLE
Add ability to set multiple namespaces to search for secrets and configMaps

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -47,7 +47,7 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Globs to match against secret data keys (Default "*").
   -secrets-label-selector value
     	Label selector to find secrets to publish as metrics.
-  -secrets-namespace string # (Deprecated) Use `-secrets-list-of-namespaces`.
+  -secrets-namespace string # (Deprecated) Use `-secrets-namespaces`.
     	Kubernetes namespace to list secrets.
   -secrets-namespaces string
         Kubernetes comma-delimited list of namespaces to search for secrets.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -47,8 +47,10 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Globs to match against secret data keys (Default "*").
   -secrets-label-selector value
     	Label selector to find secrets to publish as metrics.
-  -secrets-namespaces string
-    	Kubernetes namespaces to list secrets.
+  -secrets-namespace string # (Deprecated) Use `-secrets-list-of-namespaces`.
+    	Kubernetes to list secrets.
+  -secrets-list-of-namespaces string
+        Kubernetes list of namespaces to search for secrets.
   -configmaps-annotation-selector string
     	Annotation selector to find configmaps to publish as metrics.
   -configmaps-exclude-glob value
@@ -57,8 +59,10 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Globs to match against configmap data keys (Default "*").
   -configmaps-label-selector value
     	Label selector to find configmaps to publish as metrics.
-  -configmaps-namespaces string
-    	Kubernetes namespaces to list configmaps.
+  -configmaps-namespace string # (Deprecated) Use `-configmaps-list-of-namespaces`.
+    	Kubernetes to list configmaps.
+  -configmaps-list-of-namespaces
+        Kubernetes list of namespaces to search for configmaps.
   -enable-webhook-cert-check bool
         Enable webhook client config CABundle cert check (Default "false").
   -webhooks-label-selector

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -47,8 +47,8 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Globs to match against secret data keys (Default "*").
   -secrets-label-selector value
     	Label selector to find secrets to publish as metrics.
-  -secrets-namespace string
-    	Kubernetes namespace to list secrets.
+  -secrets-namespaces string
+    	Kubernetes namespaces to list secrets.
   -configmaps-annotation-selector string
     	Annotation selector to find configmaps to publish as metrics.
   -configmaps-exclude-glob value
@@ -57,8 +57,8 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Globs to match against configmap data keys (Default "*").
   -configmaps-label-selector value
     	Label selector to find configmaps to publish as metrics.
-  -configmaps-namespace string
-    	Kubernetes namespace to list configmaps.
+  -configmaps-namespaces string
+    	Kubernetes namespaces to list configmaps.
   -enable-webhook-cert-check bool
         Enable webhook client config CABundle cert check (Default "false").
   -webhooks-label-selector

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -49,8 +49,8 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Label selector to find secrets to publish as metrics.
   -secrets-namespace string # (Deprecated) Use `-secrets-list-of-namespaces`.
     	Kubernetes namespace to list secrets.
-  -secrets-list-of-namespaces string
-        Kubernetes list of namespaces to search for secrets.
+  -secrets-namespaces string
+        Kubernetes comma-delimited list of namespaces to search for secrets.
   -configmaps-annotation-selector string
     	Annotation selector to find configmaps to publish as metrics.
   -configmaps-exclude-glob value
@@ -61,8 +61,8 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Label selector to find configmaps to publish as metrics.
   -configmaps-namespace string # (Deprecated) Use `-configmaps-list-of-namespaces`.
     	Kubernetes namespace to list configmaps.
-  -configmaps-list-of-namespaces
-        Kubernetes list of namespaces to search for configmaps.
+  -configmaps-namespaces
+        Kubernetes comma-delimited list of namespaces to search for configmaps.
   -enable-webhook-cert-check bool
         Enable webhook client config CABundle cert check (Default "false").
   -webhooks-label-selector

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -59,7 +59,7 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Globs to match against configmap data keys (Default "*").
   -configmaps-label-selector value
     	Label selector to find configmaps to publish as metrics.
-  -configmaps-namespace string # (Deprecated) Use `-configmaps-list-of-namespaces`.
+  -configmaps-namespace string # (Deprecated) Use `-configmaps-namespaces`.
     	Kubernetes namespace to list configmaps.
   -configmaps-namespaces
         Kubernetes comma-delimited list of namespaces to search for configmaps.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -48,7 +48,7 @@ The following 15 flags are the most commonly used to control cert-exporter behav
   -secrets-label-selector value
     	Label selector to find secrets to publish as metrics.
   -secrets-namespace string # (Deprecated) Use `-secrets-list-of-namespaces`.
-    	Kubernetes to list secrets.
+    	Kubernetes namespace to list secrets.
   -secrets-list-of-namespaces string
         Kubernetes list of namespaces to search for secrets.
   -configmaps-annotation-selector string
@@ -60,7 +60,7 @@ The following 15 flags are the most commonly used to control cert-exporter behav
   -configmaps-label-selector value
     	Label selector to find configmaps to publish as metrics.
   -configmaps-namespace string # (Deprecated) Use `-configmaps-list-of-namespaces`.
-    	Kubernetes to list configmaps.
+    	Kubernetes namespace to list configmaps.
   -configmaps-list-of-namespaces
         Kubernetes list of namespaces to search for configmaps.
   -enable-webhook-cert-check bool

--- a/main.go
+++ b/main.go
@@ -36,13 +36,15 @@ var (
 	kubeconfigPath                    string
 	secretsLabelSelector              args.GlobArgs
 	secretsAnnotationSelector         args.GlobArgs
-	secretsNamespaces                 string
+	secretsNamespace                  string
+	secretsListOfNamespaces           string
 	includeSecretsDataGlobs           args.GlobArgs
 	excludeSecretsDataGlobs           args.GlobArgs
 	includeSecretsTypes               args.GlobArgs
 	configMapsLabelSelector           args.GlobArgs
 	configMapsAnnotationSelector      args.GlobArgs
-	configMapsNamespaces              string
+	configMapsNamespace               string
+	configMapsListOfNamespaces        string
 	includeConfigMapsDataGlobs        args.GlobArgs
 	excludeConfigMapsDataGlobs        args.GlobArgs
 	webhookCheckEnabled               bool
@@ -66,14 +68,16 @@ func init() {
 	flag.StringVar(&kubeconfigPath, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.Var(&secretsLabelSelector, "secrets-label-selector", "Label selector to find secrets to publish as metrics.")
 	flag.Var(&secretsAnnotationSelector, "secrets-annotation-selector", "Annotation selector to find secrets to publish as metrics.")
-	flag.StringVar(&secretsNamespaces, "secrets-namespaces", "", "Kubernetes namespaces to list secrets.")
+	flag.StringVar(&secretsNamespace, "secrets-namespace", "", "Kubernetes namespace to list secrets.")
+	flag.StringVar(&secretsListOfNamespaces, "secrets-list-of-namespaces", "", "Kubernetes list of namespaces to search for secrets.")
 	flag.Var(&includeSecretsDataGlobs, "secrets-include-glob", "Secret globs to include when looking for secret data keys (Default \"*\").")
 	flag.Var(&includeSecretsTypes, "secret-include-types", "Select only specific a secret type (Default nil).")
 	flag.Var(&excludeSecretsDataGlobs, "secrets-exclude-glob", "Secret globs to exclude when looking for secret data keys.")
 
 	flag.Var(&configMapsLabelSelector, "configmaps-label-selector", "Label selector to find configmaps to publish as metrics.")
 	flag.Var(&configMapsAnnotationSelector, "configmaps-annotation-selector", "Annotation selector to find configmaps to publish as metrics.")
-	flag.StringVar(&configMapsNamespaces, "configmaps-namespaces", "", "Kubernetes namespaces to list configmaps.")
+	flag.StringVar(&configMapsNamespace, "configmaps-namespace", "", "Kubernetes namespace to list configmaps.")
+	flag.StringVar(&configMapsListOfNamespaces, "configmaps-list-of-namespaces", "", "Kubernetes list of namespaces to search for configmaps.")
 	flag.Var(&includeConfigMapsDataGlobs, "configmaps-include-glob", "Configmap globs to include when looking for configmap data keys (Default \"*\").")
 	flag.Var(&excludeConfigMapsDataGlobs, "configmaps-exclude-glob", "Configmap globs to exclude when looking for configmap data keys.")
 
@@ -106,13 +110,16 @@ func main() {
 		if len(includeSecretsDataGlobs) == 0 {
 			includeSecretsDataGlobs = args.GlobArgs([]string{"*"})
 		}
-		var secretsNamespacesList []string
-		if len(secretsNamespaces) > 0 {
-			secretsNamespacesList = getSanitizedNamespaceList(secretsNamespaces)
+		var secretsNamespaces []string
+		if len(secretsListOfNamespaces) > 0 {
+			secretsNamespaces = getSanitizedNamespaceList(secretsListOfNamespaces)
 		} else {
-			secretsNamespacesList = append(secretsNamespacesList, "")
+			secretsNamespaces = append(secretsNamespaces, "")
 		}
-		configChecker := checkers.NewSecretChecker(pollingPeriod, secretsLabelSelector, includeSecretsDataGlobs, excludeSecretsDataGlobs, secretsAnnotationSelector, secretsNamespacesList, kubeconfigPath, &exporters.SecretExporter{}, includeSecretsTypes)
+		if len(secretsNamespace) > 0 {
+			secretsNamespaces = append(secretsNamespaces, secretsNamespace)
+		}
+		configChecker := checkers.NewSecretChecker(pollingPeriod, secretsLabelSelector, includeSecretsDataGlobs, excludeSecretsDataGlobs, secretsAnnotationSelector, secretsNamespaces, kubeconfigPath, &exporters.SecretExporter{}, includeSecretsTypes)
 		go configChecker.StartChecking()
 	}
 
@@ -126,13 +133,16 @@ func main() {
 		if len(includeConfigMapsDataGlobs) == 0 {
 			includeConfigMapsDataGlobs = args.GlobArgs([]string{"*"})
 		}
-		var configMapsNamespacesList []string
-		if len(secretsNamespaces) > 0 {
-			configMapsNamespacesList = getSanitizedNamespaceList(configMapsNamespaces)
+		var configMapsNamespaces []string
+		if len(configMapsListOfNamespaces) > 0 {
+			configMapsNamespaces = getSanitizedNamespaceList(configMapsListOfNamespaces)
 		} else {
-			configMapsNamespacesList = append(configMapsNamespacesList, "")
+			configMapsNamespaces = append(configMapsNamespaces, "")
 		}
-		configChecker := checkers.NewConfigMapChecker(pollingPeriod, configMapsLabelSelector, includeConfigMapsDataGlobs, excludeConfigMapsDataGlobs, configMapsAnnotationSelector, configMapsNamespacesList, kubeconfigPath, &exporters.ConfigMapExporter{})
+		if len(configMapsNamespace) > 0 {
+			configMapsNamespaces = append(configMapsNamespaces, configMapsNamespace)
+		}
+		configChecker := checkers.NewConfigMapChecker(pollingPeriod, configMapsLabelSelector, includeConfigMapsDataGlobs, excludeConfigMapsDataGlobs, configMapsAnnotationSelector, configMapsNamespaces, kubeconfigPath, &exporters.ConfigMapExporter{})
 		go configChecker.StartChecking()
 	}
 

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func main() {
 		var secretsNamespaces []string
 		if len(secretsListOfNamespaces) > 0 {
 			secretsNamespaces = getSanitizedNamespaceList(secretsListOfNamespaces)
-		} else {
+		} else if len(secretsNamespace) == 0 {
 			secretsNamespaces = append(secretsNamespaces, "")
 		}
 		if len(secretsNamespace) > 0 {
@@ -136,7 +136,7 @@ func main() {
 		var configMapsNamespaces []string
 		if len(configMapsListOfNamespaces) > 0 {
 			configMapsNamespaces = getSanitizedNamespaceList(configMapsListOfNamespaces)
-		} else {
+		} else if len(configMapsNamespace) == 0 {
 			configMapsNamespaces = append(configMapsNamespaces, "")
 		}
 		if len(configMapsNamespace) > 0 {

--- a/test/cert-manager/test.sh
+++ b/test/cert-manager/test.sh
@@ -76,7 +76,7 @@ echo "** Testing Label Selector And Namespace"
 $CERT_EXPORTER_PATH \
     --kubeconfig=$CONFIG_PATH \
     --secrets-annotation-selector='cert-manager.io/certificate-name' \
-    --secrets-namespaces='cert-manager-test' \
+    --secrets-namespace='cert-manager-test' \
     --secrets-include-glob='*.crt' \
     --logtostderr &
 pid=$!
@@ -93,7 +93,7 @@ echo "** Testing Label Selector And Exclude Glob"
 $CERT_EXPORTER_PATH \
     --kubeconfig=$CONFIG_PATH \
     --secrets-annotation-selector='cert-manager.io/certificate-name' \
-    --secrets-namespaces='cert-manager-test' \
+    --secrets-namespace='cert-manager-test' \
     --secrets-exclude-glob='*.key' \
     --logtostderr &
 pid=$!

--- a/test/cert-manager/test.sh
+++ b/test/cert-manager/test.sh
@@ -76,7 +76,7 @@ echo "** Testing Label Selector And Namespace"
 $CERT_EXPORTER_PATH \
     --kubeconfig=$CONFIG_PATH \
     --secrets-annotation-selector='cert-manager.io/certificate-name' \
-    --secrets-namespace='cert-manager-test' \
+    --secrets-namespaces='cert-manager-test' \
     --secrets-include-glob='*.crt' \
     --logtostderr &
 pid=$!
@@ -93,7 +93,7 @@ echo "** Testing Label Selector And Exclude Glob"
 $CERT_EXPORTER_PATH \
     --kubeconfig=$CONFIG_PATH \
     --secrets-annotation-selector='cert-manager.io/certificate-name' \
-    --secrets-namespace='cert-manager-test' \
+    --secrets-namespaces='cert-manager-test' \
     --secrets-exclude-glob='*.key' \
     --logtostderr &
 pid=$!


### PR DESCRIPTION
Add ability to set multiple namespaces to search for secrets and configMaps.

Add new parameters:
1. **-secrets-list-of-namespaces** - Kubernetes list of namespaces to search for secrets.
2. _**-configmaps-list-of-namespaces**_ -> Kubernetes list of namespaces to search for configmaps.

This parameters allow to set list of namespaces to search for secrets/configMaps. 
Example,
> `-secrets-list-of-namespaces="namespace_1,namespace_2,namespace_3"`
> `-configmaps-list-of-namespaces="namespace_1,namespace_2,namespace_3"`

**Open Issue** - #73