### PR TITLE
added additionalPodLabels

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 3.2.0
+version: 3.2.1
 appVersion: v2.9.0

--- a/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
+++ b/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       labels:
         {{- include "cert-exporter.certManagerSelectorLabels" . | nindent 8 }}
+      {{- with .Values.certManager.additionalPodLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
         {{- toYaml .Values.certManager.podAnnotations | nindent 8 }}
     spec:

--- a/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
+++ b/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
@@ -16,9 +16,9 @@ spec:
     metadata:
       labels:
         {{- include "cert-exporter.certManagerSelectorLabels" . | nindent 8 }}
-      {{- with .Values.certManager.additionalPodLabels }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- with .Values.certManager.additionalPodLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- toYaml .Values.certManager.podAnnotations | nindent 8 }}
     spec:

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -2,6 +2,10 @@ certManager:
   # DaemonSet or Deployment
   kind: Deployment
   replicaCount: 1
+  # Adds additional labels to Daemonset/Deployments
+  additionalPodLabels: {}
+  # label1: test
+  # label2: test
 
   image:
     repository: joeelliott/cert-exporter

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -2,7 +2,7 @@ certManager:
   # DaemonSet or Deployment
   kind: Deployment
   replicaCount: 1
-  # Adds additional labels to Daemonset/Deployments
+  # Adds additional labels to pods
   additionalPodLabels: {}
   # label1: test
   # label2: test


### PR DESCRIPTION
Some orgs need labels for cost analysis or other reasons. This is usually something only done on the pods.
https://github.com/joe-elliott/cert-exporter/issues/120

Before:
```
  template:
    metadata:
      labels:
        app.kubernetes.io/name: cert-exporter
        app.kubernetes.io/instance: release-name
        cert-exporter.io/type: deployment
      annotations:
        {}
    spec:
```

After (with label1/2 set to test):
```
   template:
    metadata:
      labels:
        app.kubernetes.io/name: cert-exporter
        app.kubernetes.io/instance: release-name
        cert-exporter.io/type: deployment
        label1: test
        label2: test
      annotations:
        {}
```