### PR TITLE
Helm v3.3.0 cert-exporter v2.10.0

### DIFF
--- a/docs/cert-manager.yaml
+++ b/docs/cert-manager.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: cert-exporter
       containers:
-      - image: joeelliott/cert-exporter:v2.9.0
+      - image: joeelliott/cert-exporter:v2.10.0
         name: cert-exporter
         command: ["./app"]
         args:

--- a/docs/daemonset-prom-operator.yaml
+++ b/docs/daemonset-prom-operator.yaml
@@ -19,7 +19,7 @@ spec:
         k8s-app: cert-exporter
     spec:
       containers:
-      - image: joeelliott/cert-exporter:v2.9.0
+      - image: joeelliott/cert-exporter:v2.10.0
         name: cert-exporter
         command: ["./app"]
         args:

--- a/docs/examples/custom-secrets/deployment.yaml
+++ b/docs/examples/custom-secrets/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: cert-exporter
       containers:
-      - image: joeelliott/cert-exporter:v2.9.0
+      - image: joeelliott/cert-exporter:v2.10.0
         name: cert-exporter
         command: ["./app"]
         args:

--- a/docs/kops-masters.yaml
+++ b/docs/kops-masters.yaml
@@ -27,7 +27,7 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:
-      - image: joeelliott/cert-exporter:v2.9.0
+      - image: joeelliott/cert-exporter:v2.10.0
         name: cert-exporter-masters
         command: ["./app"]
         args:

--- a/docs/kops-nodes.yaml
+++ b/docs/kops-nodes.yaml
@@ -17,7 +17,7 @@ spec:
         name: cert-exporter-nodes
     spec:
       containers:
-      - image: joeelliott/cert-exporter:v2.9.0
+      - image: joeelliott/cert-exporter:v2.10.0
         name: cert-exporter-nodes
         command: ["./app"]
         args:

--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 3.2.1
-appVersion: v2.9.0
+version: 3.3.0
+appVersion: v2.10.0

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # cert-exporter
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![version](https://img.shields.io/badge/version-2.9.0-blue.svg?cacheSeconds=2592000)
+[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![version](https://img.shields.io/badge/version-2.10.0-blue.svg?cacheSeconds=2592000)
 
 Kubernetes uses PKI certificates for authentication between all major components.  These certs are critical for the operation of your cluster but are often opaque to an administrator.  This application is designed to parse certificates and export expiration information for Prometheus to scrape.
 


### PR DESCRIPTION
Builds helm chart v3.3.0. Includes an upgrade to v2.10.0 and https://github.com/joe-elliott/cert-exporter/pull/121