### PR TITLE
Fix: pod not picking up role from service account

### DIFF
--- a/src/checkers/periodicAwsChecker.go
+++ b/src/checkers/periodicAwsChecker.go
@@ -43,7 +43,8 @@ func (p *PeriodicAwsChecker) StartChecking() {
 		p.exporter.ResetMetrics()
 
 		// Create a Session with a custom region
-		svc := secretsmanager.New(session.New(), aws.NewConfig().WithRegion(p.awsRegion))
+		session, _ := session.NewSession()
+		svc := secretsmanager.New(session, aws.NewConfig().WithRegion(p.awsRegion))
 
 		for _, secretName := range p.awsSecrets {
 			glog.Info("Getting secret " + secretName + " from AWS Secrets Manager")

--- a/src/checkers/periodicAwsChecker.go
+++ b/src/checkers/periodicAwsChecker.go
@@ -43,7 +43,14 @@ func (p *PeriodicAwsChecker) StartChecking() {
 		p.exporter.ResetMetrics()
 
 		// Create a Session with a custom region
-		session, _ := session.NewSession()
+		session, err := session.NewSession()
+		
+		if err != nil {
+			glog.Error("Error initializing AWS session: ", err)
+			metrics.ErrorTotal.Inc()
+			continue
+		}
+
 		svc := secretsmanager.New(session, aws.NewConfig().WithRegion(p.awsRegion))
 
 		for _, secretName := range p.awsSecrets {


### PR DESCRIPTION
The `cert-exporter` does not properly assume the role stored in env variable `AWS_ROLE_ARN`. Apparently, switching from `session.New()` to `session.NewSession()` should fix it: https://github.com/aws/aws-sdk-go/issues/4436