### PR TITLE
feat: add liveness + readiness Probe to deployment

### DIFF
--- a/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
+++ b/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
@@ -45,7 +45,7 @@ spec:
           {{- end}}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.certManager.containerPort }}
               protocol: TCP
           resources:
             {{- toYaml .Values.certManager.resources | nindent 12 }}
@@ -53,13 +53,13 @@ spec:
            {{- toYaml .Values.certManager.volumeMounts | nindent 12 }}
           livenessProbe:
             tcpSocket:
-              port: 8080
+              port: {{ .Values.certManager.containerPort }}
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /metrics
-              port: 8080
+              port: {{ .Values.certManager.containerPort }}
               failureThreshold: 1
               periodSeconds: 10
       {{- with .Values.certManager.nodeSelector }}

--- a/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
+++ b/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
@@ -51,6 +51,17 @@ spec:
             {{- toYaml .Values.certManager.resources | nindent 12 }}
           volumeMounts:
            {{- toYaml .Values.certManager.volumeMounts | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+              failureThreshold: 1
+              periodSeconds: 10
       {{- with .Values.certManager.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/cert-exporter/templates/cert-manager/service.yaml
+++ b/helm/cert-exporter/templates/cert-manager/service.yaml
@@ -13,6 +13,6 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       name: {{ .Values.service.portName }}
-      targetPort: 8080
+      targetPort: {{ .Values.certManager.containerPort }}
   selector:
     {{ include "cert-exporter.certManagerSelectorLabels" . | nindent 6 }}

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -63,6 +63,8 @@ certManager:
     #   name: kubelet
     #   readOnly: true
 
+  containerPort: 8080
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
## feature

* created liveness + readiness probes in the deployment. 


~~I usually dislike hard-coded ports and thought about creating a value containerPort or something similar for it (and referencing it in the service as well) but for now decided to use the hard-coded value as of now.~~

~~If you would like that more please let me know and I'll adjust it because otherwise it might get lost in future regressions~~

see 2nd commit/comment lol

closes #162 