### PR TITLE
Helm release 3.6.0

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 3.5.0
+version: 3.6.0
 appVersion: v2.12.0

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # cert-exporter
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![binary version](https://img.shields.io/badge/binary%20version-2.12.0-blue) ![helm version](https://img.shields.io/badge/helm%20version-3.15.0-blue)
+[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![binary version](https://img.shields.io/badge/binary%20version-2.12.0-blue) ![helm version](https://img.shields.io/badge/helm%20version-3.6.0-blue)
 
 Kubernetes uses PKI certificates for authentication between all major components.  These certs are critical for the operation of your cluster but are often opaque to an administrator.  This application is designed to parse certificates and export expiration information for Prometheus to scrape.
 


### PR DESCRIPTION
Cuts helm release 3.6.0 with no binary changes to catch:

https://github.com/joe-elliott/cert-exporter/pull/163

cc @CarstenSon 