### PR TITLE
adding support to specify env: via values

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 3.6.0
+version: 3.6.1
 appVersion: v2.12.0

--- a/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
+++ b/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
@@ -43,6 +43,9 @@ spec:
           args:
             {{- toYaml . | nindent 12}}
           {{- end}}
+          {{- with .Values.certManager.image.env }}
+          env: {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.certManager.containerPort }}

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -17,6 +17,12 @@ certManager:
       - --secrets-annotation-selector=cert-manager.io/certificate-name
       - --secrets-include-glob=*.crt
       - --logtostderr
+    env: []
+    # - name: NODE_NAME
+    #   valueFrom:
+    #     fieldRef:
+    #       fieldPath: spec.nodeName
+
   imagePullSecrets: []
   nameOverride: ""
   fullnameOverride: ""


### PR DESCRIPTION
Added a way to configure "env:" to allow DaemonSet to have node_name.