### PR TITLE
add metrics for x509 NotBefore attribute

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,9 @@ cert_exporter_certrequest_expires_in_seconds{cert_request="example-crt-gn762",ce
 # HELP certrequest_not_after_timestamp Timestamp when the cert in the CertificateRequest expires.
 # TYPE certrequest_not_after_timestamp gauge
 cert_exporter_certrequest_not_after_timestamp{cert_request="example-crt-gn762",certrequest_namespace="cert-manager-test",cn="example.com",issuer="example.com"}
+# HELP certrequest_not_before_timestamp Activation timestamp for cert in the certrequest.
+# TYPE certrequest_not_before_timestamp gauge
+cert_exporter_certrequest_not_before_timestamp{cert_request="example-crt-gn762",certrequest_namespace="cert-manager-test",cn="example.com",issuer="example.com"}
 ```
 
 **cert_exporter_error_total**  
@@ -89,6 +92,9 @@ The number of seconds until a certificate stored in a cert-manager CertificateRe
 
 **cert_exporter_certrequest_not_after_timestamp**
 The timestamp when a certificate stored in a cert-manager CertificateRequest expires.   The `cert_request`, `issuer`, `cn`, and `certrequest_namespace` labels indicate the CertificateRequest, comon name and namespace. 
+
+**cert_exporter_certrequest_not_before_timestamp**
+The timestamp when a certificate stored in a cert-manager CertificateRequest becomes valid.   The `cert_request`, `issuer`, `cn`, and `certrequest_namespace` labels indicate the CertificateRequest, comon name and namespace. 
 
 ### Other Docs
 

--- a/src/exporters/certExporter.go
+++ b/src/exporters/certExporter.go
@@ -18,6 +18,7 @@ func (c *CertExporter) ExportMetrics(file, nodeName string) error {
 	for _, metric := range metricCollection {
 		metrics.CertExpirySeconds.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.durationUntilExpiry)
 		metrics.CertNotAfterTimestamp.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.notAfter)
+		metrics.CertNotBeforeTimestamp.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.notBefore)
 	}
 
 	return nil
@@ -26,4 +27,5 @@ func (c *CertExporter) ExportMetrics(file, nodeName string) error {
 func (c *CertExporter) ResetMetrics() {
 	metrics.CertExpirySeconds.Reset()
 	metrics.CertNotAfterTimestamp.Reset()
+	metrics.CertNotBeforeTimestamp.Reset()
 }

--- a/src/exporters/certHelpers.go
+++ b/src/exporters/certHelpers.go
@@ -14,7 +14,7 @@ import (
 
 type certMetric struct {
 	durationUntilExpiry float64
-	notAfter            float64
+	notAfter, notBefore float64
 	issuer              string
 	cn                  string
 }
@@ -55,6 +55,7 @@ func secondsToExpiryFromCertAsBytes(certBytes []byte, certPassword string) ([]ce
 func getCertificateMetrics(cert *x509.Certificate) certMetric {
 	var metric certMetric
 	metric.notAfter = float64(cert.NotAfter.Unix())
+	metric.notBefore = float64(cert.NotBefore.Unix())
 	metric.durationUntilExpiry = time.Until(cert.NotAfter).Seconds()
 	metric.issuer = cert.Issuer.CommonName
 	metric.cn = cert.Subject.CommonName

--- a/src/exporters/certRequestExporter.go
+++ b/src/exporters/certRequestExporter.go
@@ -18,6 +18,7 @@ func (c *CertRequestExporter) ExportMetrics(bytes []byte, certrequest, certreque
 	for _, metric := range metricCollection {
 		metrics.CertRequestExpirySeconds.WithLabelValues(metric.issuer, metric.cn, certrequest, certrequestNamespace).Set(metric.durationUntilExpiry)
 		metrics.CertRequestNotAfterTimestamp.WithLabelValues(metric.issuer, metric.cn, certrequest, certrequestNamespace).Set(metric.notAfter)
+		metrics.CertRequestNotBeforeTimestamp.WithLabelValues(metric.issuer, metric.cn, certrequest, certrequestNamespace).Set(metric.notBefore)
 	}
 
 	return nil
@@ -26,4 +27,5 @@ func (c *CertRequestExporter) ExportMetrics(bytes []byte, certrequest, certreque
 func (c *CertRequestExporter) ResetMetrics() {
 	metrics.CertRequestExpirySeconds.Reset()
 	metrics.CertRequestNotAfterTimestamp.Reset()
+	metrics.CertRequestNotBeforeTimestamp.Reset()
 }

--- a/src/exporters/configMapExporter.go
+++ b/src/exporters/configMapExporter.go
@@ -18,6 +18,7 @@ func (c *ConfigMapExporter) ExportMetrics(bytes []byte, keyName, configMapName, 
 	for _, metric := range metricCollection {
 		metrics.ConfigMapExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace).Set(metric.durationUntilExpiry)
 		metrics.ConfigMapNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace).Set(metric.notAfter)
+		metrics.ConfigMapNotBeforeTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace).Set(metric.notBefore)
 	}
 
 	return nil
@@ -26,4 +27,5 @@ func (c *ConfigMapExporter) ExportMetrics(bytes []byte, keyName, configMapName, 
 func (c *ConfigMapExporter) ResetMetrics() {
 	metrics.ConfigMapExpirySeconds.Reset()
 	metrics.ConfigMapNotAfterTimestamp.Reset()
+	metrics.ConfigMapNotBeforeTimestamp.Reset()
 }

--- a/src/exporters/kubeConfigExporter.go
+++ b/src/exporters/kubeConfigExporter.go
@@ -43,6 +43,7 @@ func (c *KubeConfigExporter) ExportMetrics(file, nodeName string) error {
 		for _, metric := range metricCollection {
 			metrics.KubeConfigExpirySeconds.WithLabelValues(file, "cluster", metric.cn, metric.issuer, c.Name, nodeName).Set(metric.durationUntilExpiry)
 			metrics.KubeConfigNotAfterTimestamp.WithLabelValues(file, "cluster", metric.cn, metric.issuer, c.Name, nodeName).Set(metric.notAfter)
+			metrics.KubeConfigNotBeforeTimestamp.WithLabelValues(file, "cluster", metric.cn, metric.issuer, c.Name, nodeName).Set(metric.notBefore)
 		}
 	}
 
@@ -69,6 +70,7 @@ func (c *KubeConfigExporter) ExportMetrics(file, nodeName string) error {
 		for _, metric := range metricCollection {
 			metrics.KubeConfigExpirySeconds.WithLabelValues(file, "user", metric.cn, metric.issuer, u.Name, nodeName).Set(metric.durationUntilExpiry)
 			metrics.KubeConfigNotAfterTimestamp.WithLabelValues(file, "user", metric.cn, metric.issuer, u.Name, nodeName).Set(metric.notAfter)
+			metrics.KubeConfigNotBeforeTimestamp.WithLabelValues(file, "user", metric.cn, metric.issuer, u.Name, nodeName).Set(metric.notBefore)
 		}
 	}
 
@@ -87,4 +89,5 @@ func pathToFileFromKubeConfig(file, kubeConfigFile string) string {
 func (c *KubeConfigExporter) ResetMetrics() {
 	metrics.KubeConfigExpirySeconds.Reset()
 	metrics.KubeConfigNotAfterTimestamp.Reset()
+	metrics.KubeConfigNotBeforeTimestamp.Reset()
 }

--- a/src/exporters/secretExporter.go
+++ b/src/exporters/secretExporter.go
@@ -18,6 +18,7 @@ func (c *SecretExporter) ExportMetrics(bytes []byte, keyName, secretName, secret
 	for _, metric := range metricCollection {
 		metrics.SecretExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.durationUntilExpiry)
 		metrics.SecretNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.notAfter)
+		metrics.SecretNotBeforeTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.notBefore)
 	}
 
 	return nil
@@ -26,4 +27,5 @@ func (c *SecretExporter) ExportMetrics(bytes []byte, keyName, secretName, secret
 func (c *SecretExporter) ResetMetrics() {
 	metrics.SecretExpirySeconds.Reset()
 	metrics.SecretNotAfterTimestamp.Reset()
+	metrics.SecretNotBeforeTimestamp.Reset()
 }

--- a/src/exporters/webhookExporter.go
+++ b/src/exporters/webhookExporter.go
@@ -18,6 +18,7 @@ func (c *WebhookExporter) ExportMetrics(bytes []byte, typeName, webhookName, adm
 	for _, metric := range metricCollection {
 		metrics.WebhookExpirySeconds.WithLabelValues(typeName, metric.issuer, metric.cn, webhookName, admissionReviewVersionName).Set(metric.durationUntilExpiry)
 		metrics.WebhookNotAfterTimestamp.WithLabelValues(typeName, metric.issuer, metric.cn, webhookName, admissionReviewVersionName).Set(metric.notAfter)
+		metrics.WebhookNotBeforeTimestamp.WithLabelValues(typeName, metric.issuer, metric.cn, webhookName, admissionReviewVersionName).Set(metric.notBefore)
 	}
 
 	return nil
@@ -26,4 +27,5 @@ func (c *WebhookExporter) ExportMetrics(bytes []byte, typeName, webhookName, adm
 func (c *WebhookExporter) ResetMetrics() {
 	metrics.WebhookExpirySeconds.Reset()
 	metrics.WebhookNotAfterTimestamp.Reset()
+	metrics.WebhookNotBeforeTimestamp.Reset()
 }

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -36,6 +36,16 @@ var (
 		[]string{"filename", "issuer", "cn", "nodename"},
 	)
 
+	// CertNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
+	CertNotBeforeTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "cert_not_before_timestamp",
+			Help:      "Timestamp of when the certificate becomes valid.",
+		},
+		[]string{"filename", "issuer", "cn", "nodename"},
+	)
+
 	// KubeConfigExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubeconfig certificate expires.
 	KubeConfigExpirySeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -52,6 +62,16 @@ var (
 			Namespace: namespace,
 			Name:      "kubeconfig_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the kubeconfig.",
+		},
+		[]string{"filename", "type", "cn", "issuer", "name", "nodename"},
+	)
+
+	// KubeConfigNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
+	KubeConfigNotBeforeTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "kubeconfig_not_before_timestamp",
+			Help:      "Activation timestamp for cert in the kubeconfig.",
 		},
 		[]string{"filename", "type", "cn", "issuer", "name", "nodename"},
 	)
@@ -75,6 +95,16 @@ var (
 		},
 		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
 	)
+	
+	// SecretNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
+	SecretNotBeforeTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "secret_not_before_timestamp",
+			Help:      "Activation timestamp for cert in the secret.",
+		},
+		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
+	)
 
 	// CertRequestExpirySeconds is a prometheus gauge that indicates the number of seconds until a certificate in a cert-manager certificate request  expires
 	CertRequestExpirySeconds = prometheus.NewGaugeVec(
@@ -92,6 +122,16 @@ var (
 			Namespace: namespace,
 			Name:      "certrequest_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the certrequest.",
+		},
+		[]string{"issuer", "cn", "cert_request", "certrequest_namespace"},
+	)
+	
+	// CertRequestNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
+	CertRequestNotBeforeTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "certrequest_not_before_timestamp",
+			Help:      "Activation timestamp for cert in the certrequest.",
 		},
 		[]string{"issuer", "cn", "cert_request", "certrequest_namespace"},
 	)
@@ -125,6 +165,16 @@ var (
 		},
 		[]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"},
 	)
+	
+	// ConfigMapNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
+	ConfigMapNotBeforeTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "configmap_not_before_timestamp",
+			Help:      "Activation timestamp for cert in the configmap.",
+		},
+		[]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"},
+	)
 
 	// WebhookExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubernetes webhook certificate expires
 	WebhookExpirySeconds = prometheus.NewGaugeVec(
@@ -145,6 +195,16 @@ var (
 		},
 		[]string{"type_name", "issuer", "cn", "webhook_name", "admission_review_version_name"},
 	)
+	
+	// WebhookNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
+	WebhookNotBeforeTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "webhook_not_before_timestamp",
+			Help:      "Activation timestamp for cert in the webhook.",
+		},
+		[]string{"type_name", "issuer", "cn", "webhook_name", "admission_review_version_name"},
+	)
 )
 
 func Init(prometheusExporterMetricsDisabled bool) {
@@ -157,15 +217,21 @@ func Init(prometheusExporterMetricsDisabled bool) {
 	prometheus.MustRegister(ErrorTotal)
 	prometheus.MustRegister(CertExpirySeconds)
 	prometheus.MustRegister(CertNotAfterTimestamp)
+	prometheus.MustRegister(CertNotBeforeTimestamp)
 	prometheus.MustRegister(KubeConfigExpirySeconds)
 	prometheus.MustRegister(KubeConfigNotAfterTimestamp)
+	prometheus.MustRegister(KubeConfigNotBeforeTimestamp)
 	prometheus.MustRegister(SecretExpirySeconds)
 	prometheus.MustRegister(SecretNotAfterTimestamp)
+	prometheus.MustRegister(SecretNotBeforeTimestamp)
 	prometheus.MustRegister(CertRequestExpirySeconds)
 	prometheus.MustRegister(CertRequestNotAfterTimestamp)
+	prometheus.MustRegister(CertRequestNotBeforeTimestamp)
 	prometheus.MustRegister(ConfigMapExpirySeconds)
 	prometheus.MustRegister(ConfigMapNotAfterTimestamp)
+	prometheus.MustRegister(ConfigMapNotBeforeTimestamp)
 	prometheus.MustRegister(WebhookExpirySeconds)
 	prometheus.MustRegister(WebhookNotAfterTimestamp)
+	prometheus.MustRegister(WebhookNotBeforeTimestamp)
 	prometheus.MustRegister(AwsCertExpirySeconds)
 }


### PR DESCRIPTION
this is similar to the NotAfter metrics, except it depicts the timestamp of when the certificate *starts* to be valid.