### PR TITLE
Feature/add support for deploying additional manifest

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 3.7.0
+version: 3.8.0
 appVersion: v2.13.0

--- a/helm/cert-exporter/templates/cert-manager/extra-manifests.yaml
+++ b/helm/cert-exporter/templates/cert-manager/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl . $ }}
+{{ end }}

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -162,5 +162,5 @@ dashboards:
   additionalLabels:
     grafana_dashboard: "1"
   certManagerDashboard:
-    create: false
+    create: true
   namespace: monitoring

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -133,10 +133,34 @@ rbac:
   clusterRoleBinding:
     create: true
 
+# Extra manifests to deploy as an array
+extraManifests: []
+  # - |
+  #   apiVersion: rbac.authorization.k8s.io/v1
+  #   kind: Role
+  #   metadata:
+  #     name: cert-exporter
+  #   rules:
+  #   - apiGroups: [""]
+  #     resources: ["configmaps", "secrets"]
+  #     verbs: ["get", "list"]
+  # - |
+  #   apiVersion: rbac.authorization.k8s.io/v1
+  #   kind: RoleBinding
+  #   metadata:
+  #     name: cert-exporter
+  #   roleRef:
+  #     apiGroup: rbac.authorization.k8s.io
+  #     kind: Role
+  #     name: cert-exporter
+  #   subjects:
+  #     - kind: ServiceAccount
+  #       name: cert-exporter
+
 dashboards:
   # Labels to add to all dashboard ConfigMaps
   additionalLabels:
     grafana_dashboard: "1"
   certManagerDashboard:
-    create: true
+    create: false
   namespace: monitoring

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # cert-exporter
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![binary version](https://img.shields.io/badge/binary%20version-2.13.0-blue) ![helm version](https://img.shields.io/badge/helm%20version-3.7.0-blue)
+[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![binary version](https://img.shields.io/badge/binary%20version-2.13.0-blue) ![helm version](https://img.shields.io/badge/helm%20version-3.8.0-blue)
 
 Kubernetes uses PKI certificates for authentication between all major components.  These certs are critical for the operation of your cluster but are often opaque to an administrator.  This application is designed to parse certificates and export expiration information for Prometheus to scrape.
 


### PR DESCRIPTION
this will resolve the following issue:
Helm Chart: Add Support for Deploying Additional Manifests (e.g., Role and RoleBinding) in cert-exporter #172