### PR TITLE
conditionally add annotations key

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -3,5 +3,5 @@ name: cert-exporter
 description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
-version: 3.9.0
+version: 3.10.0
 appVersion: v2.14.0

--- a/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
+++ b/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
@@ -19,8 +19,10 @@ spec:
         {{- with .Values.certManager.additionalPodLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if .Values.certManager.podAnnotations }}
       annotations:
         {{- toYaml .Values.certManager.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.certManager.imagePullSecrets }}
       imagePullSecrets:

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # cert-exporter
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![binary version](https://img.shields.io/badge/binary%20version-2.14.0-blue) ![helm version](https://img.shields.io/badge/helm%20version-3.9.0-blue)
+[![Go Report Card](https://goreportcard.com/badge/github.com/joe-elliott/cert-exporter)](https://goreportcard.com/report/github.com/joe-elliott/cert-exporter) ![binary version](https://img.shields.io/badge/binary%20version-2.14.0-blue) ![helm version](https://img.shields.io/badge/helm%20version-3.10.0-blue)
 
 Kubernetes uses PKI certificates for authentication between all major components.  These certs are critical for the operation of your cluster but are often opaque to an administrator.  This application is designed to parse certificates and export expiration information for Prometheus to scrape.
 


### PR DESCRIPTION
While deploying with ArgoCD, I faced and issue where application is out of sync after daemonset restart.

This is because helm render "forces" empty annotations.
![image](https://github.com/user-attachments/assets/c29aa187-6db7-4379-85a0-8588fa8ad4a1)
