### PR TITLE
Add namespace to chart, support for custom namespace

### DIFF
--- a/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
+++ b/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: {{ .Values.certManager.kind }}
 metadata:
   name: "{{- include "cert-exporter.fullname" . -}}-cert-manager"
+  namespace: {{ .Values.certManager.namespace }}
   labels:
     {{- include "cert-exporter.certManagerLabels" . | nindent 4 }}
 spec:

--- a/helm/cert-exporter/templates/cert-manager/service.yaml
+++ b/helm/cert-exporter/templates/cert-manager/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-exporter.fullname" . }}
+  namespace: {{ .Values.certManager.namespace }}
   labels:
     {{- include "cert-exporter.certManagerLabels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -1,6 +1,7 @@
 certManager:
   # DaemonSet or Deployment
   kind: Deployment
+  namespace: monitoring
   replicaCount: 1
   # Adds additional labels to pods
   additionalPodLabels: {}
@@ -10,7 +11,7 @@ certManager:
   image:
     repository: joeelliott/cert-exporter
     # The default tag is ".Chart.AppVersion", only set "tag" to override that
-    tag: 
+    tag:
     pullPolicy: IfNotPresent
     command: ["./app"]
     args:


### PR DESCRIPTION
### Summary of Changes
- **Namespace Support**: Added `namespace` field to `cert-manager.yaml`, `service.yaml`, and `values.yaml` with a default value of `monitoring`.
- **Tag Update**: Made the `tag` field in `values.yaml` customizable, defaulting to `.Chart.AppVersion`.

These changes enhance flexibility for namespace configuration and image tag management.

Local tests for another namespace:
```
helm upgrade \
  --install cert-exporter helm/cert-exporter/ \
  --set certManager.namespace=service \
  --set dashboards.namespace=service \
  --values helm/cert-exporter/values.yaml

```