### PR TITLE
Allow using namespace label selector instead of fixed namespace names

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -28,7 +28,7 @@ cert-exporter also supports certificates stored in Kubernetes secrets and config
 `--secrets-annotation-selector=cert-manager.io/certificate-name`
 
 ### flags
-The following 15 flags are the most commonly used to control cert-exporter behavior.  They allow you to use file globs to include and exclude certs and kubeconfig files.
+The following 17 flags are the most commonly used to control cert-exporter behavior.  They allow you to use file globs to include and exclude certs and kubeconfig files.
 
 ```
   -exclude-cert-glob value
@@ -51,6 +51,8 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Kubernetes namespace to list secrets.
   -secrets-namespaces string
         Kubernetes comma-delimited list of namespaces to search for secrets.
+  -secrets-namespace-label-selector value
+        Label selector to find namespaces in which to find secrets to publish as metrics.
   -configmaps-annotation-selector string
     	Annotation selector to find configmaps to publish as metrics.
   -configmaps-exclude-glob value
@@ -63,6 +65,8 @@ The following 15 flags are the most commonly used to control cert-exporter behav
     	Kubernetes namespace to list configmaps.
   -configmaps-namespaces
         Kubernetes comma-delimited list of namespaces to search for configmaps.
+  -configmaps-namespace-label-selector value
+        Label selector to find namespaces in which to find configmaps to publish as metrics.
   -enable-webhook-cert-check bool
         Enable webhook client config CABundle cert check (Default "false").
   -webhooks-label-selector

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -129,6 +129,9 @@ rbac:
     - apiGroups: [""]
       resources: ["secrets"]
       verbs: ["get", "list"]
+    - apiGroups: [""]
+      resources: ["namespaces"]
+      verbs: ["get", "list"]
 
   clusterRoleBinding:
     create: true


### PR DESCRIPTION
Apparently we are using this cert-exporter for a few days in prod now :) and I really did not like keeping a long list of namespaces (especially since we now create lots of ns's on-demand dynamically) with certificates. We do not however want to monitor tenant's  certificates!

I added an option to specify - instead of just fixed namespace names - label selector for namespaces to both configmap and secrets.

How would you feel about this PR? :) I will update docs if it looks good.