### PR TITLE
Add namespace to helm (template) - helm issue 3553

### DIFF
--- a/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
+++ b/helm/cert-exporter/templates/cert-manager/cert-manager.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: {{ .Values.certManager.kind }}
 metadata:
   name: "{{- include "cert-exporter.fullname" . -}}-cert-manager"
+  namespace: {{ .Values.dashboards.namespace }}
   labels:
     {{- include "cert-exporter.certManagerLabels" . | nindent 4 }}
 spec:

--- a/helm/cert-exporter/templates/cert-manager/service.yaml
+++ b/helm/cert-exporter/templates/cert-manager/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-exporter.fullname" . }}
+  namespace: {{ .Values.dashboards.namespace }}
   labels:
     {{- include "cert-exporter.certManagerLabels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/helm/cert-exporter/templates/cert-manager/servicemonitor.yaml
+++ b/helm/cert-exporter/templates/cert-manager/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "cert-exporter.fullname" . }}-cert-manager
+  namespace: {{ .Values.dashboards.namespace }}
   labels:
     {{- toYaml .Values.service.serviceMonitor.additionalLabels | nindent 4 }}
     {{- include "cert-exporter.certManagerLabels" . | nindent 4 }}


### PR DESCRIPTION
Helm only adds "namespace" to "helm template" and helm dry-run if it is specified in the original teplate. This adds the namespace.

Upstream reason: 
https://github.com/helm/helm/issues/3553#issuecomment-2235841549