### PR TITLE
Upgrade Docker base image (Alpine) from 3.16 to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN go mod download && \
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:3.16
+FROM alpine:3.21
 
 RUN addgroup -g 1000 app && \
     adduser -u 1000 -h /app -G app -S app


### PR DESCRIPTION
Alpine 3.16 is EOL since mid of 2024: https://alpinelinux.org/releases/

So let's switch to the latest stable one. 🙂 