### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,5 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Enable automatic PR creation for Docker image updates. Should make manual updates like in https://github.com/joe-elliott/cert-exporter/pull/185 obsolete. 🙂 