### PR TITLE
Update chart release to skip existing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: helm
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
It seems there was a behavior change in this update:

https://github.com/joe-elliott/cert-exporter/commit/57bea1f73259384c9c1a544e5ed9ab6abf48d15e

Passing `skip_existing: true` to restore the old behavior.