### PR TITLE
fix: use assignment for namespaces in configmap and secrets checker

### DIFF
--- a/src/checkers/periodicConfigMapChecker.go
+++ b/src/checkers/periodicConfigMapChecker.go
@@ -87,7 +87,7 @@ func (p *PeriodicConfigMapChecker) StartChecking() {
 				}
 			}
 		} else {
-			namespacesToCheck = append(namespacesToCheck, p.namespaces...)
+			namespacesToCheck = p.namespaces
 		}
 
 		for _, ns := range namespacesToCheck {

--- a/src/checkers/periodicConfigMapChecker.go
+++ b/src/checkers/periodicConfigMapChecker.go
@@ -87,7 +87,7 @@ func (p *PeriodicConfigMapChecker) StartChecking() {
 				}
 			}
 		} else {
-			copy(namespacesToCheck, p.namespaces)
+			namespacesToCheck = append(namespacesToCheck, p.namespaces...)
 		}
 
 		for _, ns := range namespacesToCheck {

--- a/src/checkers/periodicSecretChecker.go
+++ b/src/checkers/periodicSecretChecker.go
@@ -88,7 +88,7 @@ func (p *PeriodicSecretChecker) StartChecking() {
 				}
 			}
 		} else {
-			copy(namespacesToCheck, p.namespaces)
+			namespacesToCheck = p.namespaces
 		}
 
 		for _, ns := range namespacesToCheck {


### PR DESCRIPTION
> The copy built-in function copies elements from a source slice into a destination slice. (As a special case, it also will copy bytes from a string to a slice of bytes.) The source and destination may overlap. Copy returns the number of elements copied, which will be the minimum of len(src) and len(dst).

In this case, `namespacesToCheck` is declared as a nil string slice. When the `copy` function is called, it will create a new slice that's the minimum of the two inputs. In this case, that's zero, so namespaces are never copied correctly in this path.

Instead `namespacesToCheck` needs to use `append` so that a new slice is created with the contents as expected.