### PR TITLE
Feat: Adding different usecase for AWS, incl. basic documentation for AWS usage

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -82,3 +82,36 @@ For a full flag listing run the application with the `--help` parameter.
 ### environment variables
 
 cert-exporter respects the `NODE_NAME` environment variable.  If present it will add this value as label to file metrics.  See one of the [deployment yamls](./kops-nodes.yaml) for an example of using the [Kubernetes Downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/) to make use of this feature.
+
+### AWS
+
+cert-exporter is able to check secrets in AWS Secret Manager. The following arguments exist for monitoring certificates in AWS Secret Manager:
+
+```
+  -aws-account string
+        AWS account to search for secrets in
+  -aws-key-string string
+        Name of the key to check in secrets (default ".pem")
+  -aws-region string
+        AWS region to search for secrets in
+  -aws-secret value
+        AWS secrets to export
+```
+
+Multiple `-aws-secret` arguments can be provided to monitor more than 1 secret. Example of 2 possible cases when using AWS Secret Manager:
+
+```json
+{
+    "tls.pem": "-----BEGIN CERTIFICATE-----\nMIID7TCCAtWgAwIBAgIUUC0QZlGksaxYSfvF7RoC9O44VYEwDQYJKoZIhvcNAQEL\n...\n-----END CERTIFICATE-----",
+    "tls.key": "-----BEGIN PRIVATE KEY-----\MIIFNTBfBgkqhkiG9w0BBQ0wUjAxBgkqhkiG9w0BBQwwJAQQwlrvimumxjmK50ne\n...\n-----END PRIVATE KEY-----",
+}
+```
+
+or base64 encoded:
+
+```json
+{
+    "tls.pem": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQ3VENDQXRXZ0F3SUJBZ0lVVUMwUVpsR2tzYXhZU2Z2RjdSb0M5TzQ0VllFd0RRWUpLb1pJaHZjTkFRRUw...",
+    "tls.key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tXE1JSUZOVEJmQmdrcWhraUc5dzBCQlEwd1VqQXhCZ2txaGtpRzl3MEJCUXd3SkFRUXdscnZpbXVteGptSzUwbmU...",
+}
+```

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ var (
 	webhooksAnnotationSelector        args.GlobArgs
 	awsAccount                        string
 	awsRegion                         string
+	awsKeyString                      string
 	awsSecrets                        args.GlobArgs
 	certRequestsEnabled               bool
 	certRequestsLabelSelector         args.GlobArgs
@@ -96,6 +97,7 @@ func init() {
 
 	flag.StringVar(&awsAccount, "aws-account", "", "AWS account to search for secrets in")
 	flag.StringVar(&awsRegion, "aws-region", "", "AWS region to search for secrets in")
+	flag.StringVar(&awsKeyString, "aws-key-string", ".pem", "Name of the key to check in secrets")
 	flag.Var(&awsSecrets, "aws-secret", "AWS secrets to export")
 
 	flag.BoolVar(&certRequestsEnabled, "enable-certrequests-check", false, "Enable certrequests check.")
@@ -142,7 +144,7 @@ func main() {
 
 	if len(awsAccount) > 0 && len(awsRegion) > 0 && len(awsSecrets) > 0 {
 		glog.Infof("Starting check for AWS Secrets Manager in Account %s and Region %s and Secrets %s", awsAccount, awsRegion, awsSecrets)
-		awsChecker := checkers.NewAwsChecker(awsAccount, awsRegion, awsSecrets, pollingPeriod, &exporters.AwsExporter{})
+		awsChecker := checkers.NewAwsChecker(awsAccount, awsRegion, awsKeyString, awsSecrets, pollingPeriod, &exporters.AwsExporter{})
 		go awsChecker.StartChecking()
 	}
 

--- a/src/checkers/periodicAwsChecker.go
+++ b/src/checkers/periodicAwsChecker.go
@@ -1,6 +1,7 @@
 package checkers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"time"
@@ -17,20 +18,21 @@ import (
 
 // PeriodicAwsChecker is an object designed to check for .pem files in AWS Secrets Manager
 type PeriodicAwsChecker struct {
-	awsAccount, awsRegion string
-	awsSecrets            []string
-	period                time.Duration
-	exporter              *exporters.AwsExporter
+	awsAccount, awsRegion, awsKeyString string
+	awsSecrets                          []string
+	period                              time.Duration
+	exporter                            *exporters.AwsExporter
 }
 
 // NewCertChecker is a factory method that returns a new AwsCertChecker
-func NewAwsChecker(awsAccount, awsRegion string, awsSecrets []string, period time.Duration, e *exporters.AwsExporter) *PeriodicAwsChecker {
+func NewAwsChecker(awsAccount, awsRegion, awsKeyString string, awsSecrets []string, period time.Duration, e *exporters.AwsExporter) *PeriodicAwsChecker {
 	return &PeriodicAwsChecker{
-		awsAccount: awsAccount,
-		awsRegion:  awsRegion,
-		awsSecrets: awsSecrets,
-		period:     period,
-		exporter:   e,
+		awsAccount:   awsAccount,
+		awsRegion:    awsRegion,
+		awsKeyString: awsKeyString,
+		awsSecrets:   awsSecrets,
+		period:       period,
+		exporter:     e,
 	}
 }
 
@@ -44,7 +46,7 @@ func (p *PeriodicAwsChecker) StartChecking() {
 
 		// Create a Session with a custom region
 		session, err := session.NewSession()
-		
+
 		if err != nil {
 			glog.Error("Error initializing AWS session: ", err)
 			metrics.ErrorTotal.Inc()
@@ -74,9 +76,16 @@ func (p *PeriodicAwsChecker) StartChecking() {
 			json.Unmarshal([]byte(secretString), &secretMap)
 
 			for key, value := range secretMap {
-				if strings.Contains(key, ".pem") {
+				// if strings.Contains(key, ".pem") {
+				if strings.Contains(key, p.awsKeyString) {
+					stringValue := value.(string)
+
+					if strings.HasPrefix(stringValue, "-----BEGIN CERTIFICATE-----") {
+						stringValue = base64.StdEncoding.EncodeToString([]byte(stringValue))
+					}
+
 					glog.Info("Exporting metrics from ", key)
-					err := p.exporter.ExportMetrics(value.(string), secretName, key)
+					err := p.exporter.ExportMetrics(stringValue, secretName, key)
 					if err != nil {
 						metrics.ErrorTotal.Inc()
 						glog.Error("Error exporting certificate metrics")


### PR DESCRIPTION
The current check for monitoring certificates assumes that a key contains a base64 encoded value. In my setup I have several secrets in AWS Secret Manager that is used for (several) lambda's where we have stored the certificate on a single line (`"-----BEGIN CERTIFICATE-----\nMIID7TCCAtWgAwIBAgIUUC0QZlGksaxYSfvF7RoC9O44VYEwDQYJKoZIhvcNAQEL\n...\n-----END CERTIFICATE-----"`).

This PR checks if - very basic - if a `"BEGIN CERTIFICATE"` is found and if so, it will base64 encode the complete value. This resulted in minimal changes in the code. Next to this, an extra argument is added (aws-key-string) where you can specify the name of the key instead using the default (and previously hardcoded) ".pem".

Also added some very basic documentation about the AWS Secret Manager monitoring.