### PR TITLE
Use ENTRYPOINT ["./app"] instead of CMD to fix issues with args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ USER app
 
 COPY --from=build /src/app .
 
-CMD ["./app"] 
+ENTRYPOINT ["./app"]
+CMD []


### PR DESCRIPTION
Fixes #214

  1. Existing usage without args - Works identically:
    - Before: docker run image → runs ./app
    - After: docker run image → runs ./app
  2. Existing usage with args - This is what's currently BROKEN and will be FIXED:
    - Before: docker run image --flag → tries to run --flag as executable ❌
    - After: docker run image --flag → runs ./app --flag ✅
  3. Kubernetes without args - Works identically:
    - Before: command: ["./app"] → runs ./app
    - After: Nothing specified → runs ./app
  4. Kubernetes with args - This is what's currently BROKEN and will be FIXED:
    - Before: args: ["--flag"] doesn't work without command: ["./app"] ❌
    - After: args: ["--flag"] → runs ./app --flag ✅
    
