### PR TITLE
Bump Go to 1.26 in go.mod and CI to fix CVE-2025-68121

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go ^1.23
+      - name: Set up Go ^1.26
         uses: actions/setup-go@v6
         with:
-          go-version: ^1.23
+          go-version: ^1.26
 
       - name: Clean Helm Tags
         run: git tag -d $(git tag -l "cert-exporter*")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Set up Go ^1.23
+      - name: Set up Go ^1.26
         uses: actions/setup-go@v6
         with:
-          go-version: ^1.23
+          go-version: ^1.26
 
       - name: Configure Git
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,12 @@ builds:
     goarch:
       - amd64
       - arm
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: arm
     flags:
       - -v
       - -trimpath

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/joe-elliott/cert-exporter
 
-go 1.23.0
-
-toolchain go1.23.3
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8

--- a/test/files/test.sh
+++ b/test/files/test.sh
@@ -5,6 +5,21 @@
 
 set -o errexit
 
+waitForMetrics() {
+    for i in $(seq 1 10); do
+        if curl --silent --fail http://localhost:8080/metrics > /dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "ERROR: metrics endpoint not ready after 10 seconds"
+    exit 1
+}
+
+fetchMetrics() {
+    curl --silent http://localhost:8080/metrics
+}
+
 fetchMetricsTimestampValue() {
     local metrics
     metrics="$1"
@@ -85,10 +100,11 @@ mkdir certs
 # run exporter
 $CERT_EXPORTER_PATH -include-cert-glob=certs/*.crt  -include-kubeconfig-glob=certs/kubeconfig &
 
-sleep 2
+waitForMetrics
 
-curl --silent http://localhost:8080/metrics | grep 'cert_exporter_discovered 5'
-curl --silent http://localhost:8080/metrics | grep 'cert_exporter_error_total 0'
+metrics=$(fetchMetrics)
+echo "$metrics" | grep 'cert_exporter_discovered 5'
+echo "$metrics" | grep 'cert_exporter_error_total 0'
 
 activation=$(date +%s) # this timestamp is at least 2 seconds off from the actual cert NotBefore attribute ...
 validateTimestampBefore 'cert_exporter_cert_not_before_timestamp{cn="client",filename="certs/client.crt",issuer="root",nodename="master0"}' $activation
@@ -134,9 +150,9 @@ mkdir kubeConfigSibling
 # run exporter
 $CERT_EXPORTER_PATH -include-cert-glob=certsSibling/*.crt  -include-kubeconfig-glob=kubeConfigSibling/kubeconfig &
 
-sleep 2
+waitForMetrics
 
-curl --silent http://localhost:8080/metrics | grep 'cert_exporter_error_total 0'
+echo "$(fetchMetrics)" | grep 'cert_exporter_error_total 0'
 
 activation=$(date +%s) # this timestamp is at least 2 seconds off from the actual cert NotBefore attribute ...
 validateTimestampBefore 'cert_exporter_cert_not_after_timestamp{cn="client",filename="certsSibling/client.crt",issuer="root",nodename="master0"}' $activation
@@ -169,9 +185,9 @@ echo 'asdfasdf' > certs/client.crt
 # run exporter
 $CERT_EXPORTER_PATH -include-cert-glob=certs/client.crt &
 
-sleep 2
+waitForMetrics
 
-curl --silent http://localhost:8080/metrics | grep 'cert_exporter_error_total 1'
+echo "$(fetchMetrics)" | grep 'cert_exporter_error_total 1'
 
 # kill exporter
 kill $!


### PR DESCRIPTION
## Summary
- Updates `go.mod` from Go 1.23.0 to 1.26.0 (the Dockerfile was already bumped to `golang:1.26` in #238)
- Updates CI and release workflow `go-version` from `^1.23` to `^1.26`
- Removes `windows/arm` and `darwin/arm` from goreleaser targets (Go 1.26 dropped `windows/arm`) and adds `arm64`
- Fixes test.sh server readiness race condition exposed by Go 1.26

Fixes #242

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] CI passes (all steps: build, unit tests, integration tests, cert tests, cert-manager tests, release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)