### PR TITLE
chore: bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - name: Set up Go ^1.26
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ^1.26
+          go-version: '1.26.5'
 
       - name: Clean Helm Tags
         run: git tag -d $(git tag -l "cert-exporter*")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -23,10 +23,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Set up Go ^1.26
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ^1.26
+          go-version: '1.26.5'
 
       - name: Configure Git
         run: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: joeelliott/cert-exporter
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.26 as build
+FROM golang:1.26.5 as build
 WORKDIR /src
 
 COPY . .
 RUN go mod download && \
     CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
-FROM alpine:3.23
+FROM alpine:3.24
 
 RUN addgroup -g 1000 app && \
     adduser -u 1000 -h /app -G app -S app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/joe-elliott/cert-exporter
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ cert_exporter_certrequest_not_before_timestamp{cert_request="example-crt-gn762",
 ```
 
 **cert_exporter_discovered**
-The number of discovered certs after the include and exclude globs are factored in. The `nodename` can be used as a label to compare values.
+The number of files matched by include/exclude globs across all file-based checkers (certificate files and kubeconfig files). Concurrent checkers accumulate into this gauge rather than overwriting it.
 
 **cert_exporter_error_total**  
 The total number of unexpected errors encountered by cert-exporter.  A good metric to watch to feel comfortable certs are being exported properly.

--- a/src/checkers/periodicCertChecker.go
+++ b/src/checkers/periodicCertChecker.go
@@ -50,6 +50,10 @@ type PeriodicCertChecker struct {
 	excludeCertGlobs []*certGlob
 	nodeName         string
 	exporter         exporters.Exporter
+	// lastDiscovered is this checker's previous contribution to the shared
+	// metrics.Discovered gauge. Each checker adjusts the gauge by delta so
+	// concurrent cert and kubeconfig checkers accumulate instead of overwrite.
+	lastDiscovered float64
 }
 
 // NewCertChecker is a factory method that returns a new PeriodicCertChecker
@@ -80,21 +84,25 @@ func (p *PeriodicCertChecker) StartChecking() {
 	periodChannel := time.Tick(p.period)
 
 	for {
-		slog.Info("Begin periodic check")
-
-		p.exporter.ResetMetrics()
-
-		for _, match := range p.getMatches() {
-			slog.Info("Publishing node metrics", "nodeName", p.nodeName, "match", match)
-
-			err := p.exporter.ExportMetrics(match, p.nodeName)
-			if err != nil {
-				metrics.ErrorTotal.Inc()
-				slog.Error("Error exporting metrics", "match", match, "error", err)
-			}
-		}
-
+		p.checkOnce()
 		<-periodChannel
+	}
+}
+
+// checkOnce performs a single scan-and-export cycle (used by tests without leaking a goroutine).
+func (p *PeriodicCertChecker) checkOnce() {
+	slog.Info("Begin periodic check")
+
+	p.exporter.ResetMetrics()
+
+	for _, match := range p.getMatches() {
+		slog.Info("Publishing node metrics", "nodeName", p.nodeName, "match", match)
+
+		err := p.exporter.ExportMetrics(match, p.nodeName)
+		if err != nil {
+			metrics.ErrorTotal.Inc()
+			slog.Error("Error exporting metrics", "match", match, "error", err)
+		}
 	}
 }
 
@@ -130,7 +138,12 @@ func (p *PeriodicCertChecker) getMatches() []string {
 		}
 	}
 
-	metrics.Discovered.Set(float64(len(set)))
+	// Adjust the shared gauge by this checker's contribution only. Using Set
+	// here would race with other PeriodicCertChecker goroutines (e.g. cert +
+	// kubeconfig) and leave the metric at whichever finished last.
+	n := float64(len(set))
+	metrics.Discovered.Add(n - p.lastDiscovered)
+	p.lastDiscovered = n
 
 	res := make([]string, len(set))
 	i := 0

--- a/src/checkers/periodicCertChecker_test.go
+++ b/src/checkers/periodicCertChecker_test.go
@@ -3,6 +3,7 @@ package checkers
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -130,23 +131,12 @@ func TestPeriodicCertChecker_StartChecking(t *testing.T) {
 	testutil.WriteCertToFile(t, cert1.CertPEM, filepath.Join(tmpDir, "cert1.crt"))
 	testutil.WriteCertToFile(t, cert2.CertPEM, filepath.Join(tmpDir, "cert2.crt"))
 
-	// Create checker with short period
 	includeGlobs := []string{tmpDir + "/*.crt"}
 	excludeGlobs := []string{}
-	checker := NewCertChecker(100*time.Millisecond, includeGlobs, excludeGlobs, "test-node", &exporters.CertExporter{})
+	checker := NewCertChecker(time.Hour, includeGlobs, excludeGlobs, "test-node", &exporters.CertExporter{})
 
-	// Start checking in a goroutine
-	done := make(chan bool)
-	go func() {
-		// Run for a short time
-		time.Sleep(250 * time.Millisecond)
-		done <- true
-	}()
-
-	go checker.StartChecking()
-
-	// Wait for checker to run at least once
-	time.Sleep(150 * time.Millisecond)
+	// Run a single check cycle (avoids leaking a forever-running StartChecking goroutine)
+	checker.checkOnce()
 
 	// Verify metrics were created
 	mfs, err := testRegistry.Gather()
@@ -169,13 +159,91 @@ func TestPeriodicCertChecker_StartChecking(t *testing.T) {
 	if !foundMetrics {
 		t.Errorf("Expected to find metrics for 2 certificates, found %d", metricCount)
 	}
+}
 
-	<-done
+func TestPeriodicCertChecker_DiscoveredAccumulation(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	metrics.Init(true, testRegistry)
+	// Discovered is a process-global gauge; zero it so this test is isolated.
+	metrics.Discovered.Set(0)
+
+	tmpDir := testutil.CreateTempCertDir(t)
+
+	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
+		CommonName: "disc-test", Organization: "org", Country: "US", Province: "CA", Days: 30,
+	})
+	testutil.WriteCertToFile(t, cert.CertPEM, filepath.Join(tmpDir, "a.crt"))
+	testutil.WriteCertToFile(t, cert.CertPEM, filepath.Join(tmpDir, "b.crt"))
+	// Second checker watches a different glob (mirrors cert + kubeconfig in main).
+	testutil.WriteCertToFile(t, cert.CertPEM, filepath.Join(tmpDir, "extra.pem"))
+
+	checkerA := NewCertChecker(
+		time.Hour,
+		[]string{tmpDir + "/*.crt"},
+		[]string{},
+		"node",
+		&exporters.CertExporter{},
+	)
+	checkerB := NewCertChecker(
+		time.Hour,
+		[]string{tmpDir + "/*.pem"},
+		[]string{},
+		"node",
+		&exporters.CertExporter{},
+	)
+
+	// Both checkers contribute: 2 .crt + 1 .pem = 3 (not a racey overwrite of 2 or 1).
+	checkerA.checkOnce()
+	checkerB.checkOnce()
+	if got := gatherDiscovered(t, testRegistry); got != 3 {
+		t.Fatalf("after both checkers: discovered = %v, want 3", got)
+	}
+
+	// Re-running must not double-count (delta adjustment).
+	checkerA.checkOnce()
+	checkerB.checkOnce()
+	if got := gatherDiscovered(t, testRegistry); got != 3 {
+		t.Fatalf("after re-run: discovered = %v, want 3", got)
+	}
+
+	// Removing a file updates the total by this checker's delta only.
+	if err := os.Remove(filepath.Join(tmpDir, "b.crt")); err != nil {
+		t.Fatal(err)
+	}
+	checkerA.checkOnce()
+	if got := gatherDiscovered(t, testRegistry); got != 2 {
+		t.Fatalf("after removing one cert: discovered = %v, want 2", got)
+	}
+}
+
+func gatherDiscovered(t *testing.T, reg *prometheus.Registry) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == "cert_exporter_discovered" && len(mf.GetMetric()) > 0 {
+			return mf.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	t.Fatal("cert_exporter_discovered not found")
+	return 0
 }
 
 func TestPeriodicCertChecker_ErrorHandling(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
 	metrics.Init(true, testRegistry)
+
+	// Capture error_total before this test; the counter is process-global.
+	var errorCountBefore float64
+	if mfs, err := testRegistry.Gather(); err == nil {
+		for _, mf := range mfs {
+			if mf.GetName() == "cert_exporter_error_total" && len(mf.GetMetric()) > 0 {
+				errorCountBefore = mf.GetMetric()[0].GetCounter().GetValue()
+			}
+		}
+	}
 
 	tmpDir := testutil.CreateTempCertDir(t)
 
@@ -185,79 +253,61 @@ func TestPeriodicCertChecker_ErrorHandling(t *testing.T) {
 	})
 	testutil.WriteCertToFile(t, cert.CertPEM, filepath.Join(tmpDir, "valid.crt"))
 
-	// Create an invalid certificate file
+	// Create an invalid certificate file (plaintext garbage — not PEM or PKCS#12)
 	invalidFile := filepath.Join(tmpDir, "invalid.crt")
 	err := os.WriteFile(invalidFile, []byte("not a valid certificate"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Create checker
 	includeGlobs := []string{tmpDir + "/*.crt"}
-	nodeName := "test-node-error-" + tmpDir[len(tmpDir)-10:] // unique node name
-	checker := NewCertChecker(100*time.Millisecond, includeGlobs, []string{}, nodeName, &exporters.CertExporter{})
+	nodeName := "test-node-error-" + filepath.Base(tmpDir)
+	checker := NewCertChecker(time.Hour, includeGlobs, []string{}, nodeName, &exporters.CertExporter{})
 
-	// Start checking
-	go checker.StartChecking()
+	// Single synchronous cycle: invalid cert should error, valid cert should still export
+	checker.checkOnce()
 
-	// Poll for metrics with timeout (allows time for async processing)
-	maxWait := 500 * time.Millisecond
-	checkInterval := 50 * time.Millisecond
-	deadline := time.Now().Add(maxWait)
+	mfs, err := testRegistry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
 
 	var errorCount float64
 	var validMetricFound bool
-
-	for time.Now().Before(deadline) {
-		mfs, err := testRegistry.Gather()
-		if err != nil {
-			t.Fatalf("Failed to gather metrics: %v", err)
-		}
-
-		// Check error count
-		for _, mf := range mfs {
-			if mf.GetName() == "cert_exporter_error_total" {
-				if len(mf.GetMetric()) > 0 {
-					errorCount = mf.GetMetric()[0].GetCounter().GetValue()
-				}
-				break
+	for _, mf := range mfs {
+		switch mf.GetName() {
+		case "cert_exporter_error_total":
+			if len(mf.GetMetric()) > 0 {
+				errorCount = mf.GetMetric()[0].GetCounter().GetValue()
 			}
-		}
-
-		// Check for valid certificate metric
-		validMetricFound = false
-		for _, mf := range mfs {
-			if mf.GetName() == "cert_exporter_cert_expires_in_seconds" {
-				for _, metric := range mf.GetMetric() {
-					labels := make(map[string]string)
-					for _, label := range metric.GetLabel() {
-						labels[label.GetName()] = label.GetValue()
-					}
-					if labels["cn"] == "valid-cert" && labels["nodename"] == nodeName {
-						validMetricFound = true
-						break
-					}
+		case "cert_exporter_cert_expires_in_seconds":
+			for _, metric := range mf.GetMetric() {
+				labels := make(map[string]string)
+				for _, label := range metric.GetLabel() {
+					labels[label.GetName()] = label.GetValue()
 				}
-				if validMetricFound {
-					break
+				if labels["cn"] == "valid-cert" && labels["nodename"] == nodeName {
+					validMetricFound = true
 				}
 			}
 		}
-
-		// If we have both error count and valid metric, we're done
-		if errorCount >= 1 && validMetricFound {
-			break
-		}
-
-		time.Sleep(checkInterval)
 	}
 
-	// Should have at least one error from the invalid certificate
-	if errorCount < 1 {
-		t.Errorf("Expected error_total >= 1, got %v", errorCount)
+	if errorCount < errorCountBefore+1 {
+		t.Errorf("Expected error_total to increase by at least 1 (before=%v, after=%v)", errorCountBefore, errorCount)
 	}
 
 	if !validMetricFound {
 		t.Error("Expected to find metrics for valid certificate despite error in invalid certificate")
+	}
+
+	// Also verify ExportMetrics surfaces a stable parse failure for invalid text
+	// (not a brittle PKCS#12 ASN.1 detail that changes across crypto/asn1 versions).
+	exportErr := (&exporters.CertExporter{}).ExportMetrics(invalidFile, nodeName)
+	if exportErr == nil {
+		t.Fatal("Expected ExportMetrics to fail for invalid certificate text")
+	}
+	if !strings.Contains(exportErr.Error(), "failed to parse as pem and pkcs12") {
+		t.Errorf("Expected parse failure wrapper, got: %v", exportErr)
 	}
 }

--- a/src/exporters/certHelpers.go
+++ b/src/exporters/certHelpers.go
@@ -41,16 +41,30 @@ func secondsToExpiryFromCertAsBase64String(s string) ([]certMetric, error) {
 func secondsToExpiryFromCertAsBytes(certBytes []byte, certPassword string) ([]certMetric, error) {
 	var metrics []certMetric
 
-	parsed, metrics, err := parseAsPEM(certBytes)
+	parsed, metrics, pemErr := parseAsPEM(certBytes)
 	if parsed {
-		return metrics, err
+		return metrics, pemErr
 	}
-	// Parse as PKCS ?
-	parsed, metrics, err = parseAsPKCS(certBytes, certPassword)
+	// Fall back to PKCS#12 for binary keystore formats (.p12/.pfx).
+	parsed, metrics, pkcsErr := parseAsPKCS(certBytes, certPassword)
 	if parsed {
 		return metrics, nil
 	}
-	return nil, fmt.Errorf("failed to parse as pem and pkcs12: %w", err)
+	// Prefer the PEM error when the payload is clearly textual; PKCS#12 ASN.1
+	// errors on garbage text are noisy and change across crypto/asn1 versions.
+	if pemErr != nil && !looksLikePKCS12(certBytes) {
+		return nil, fmt.Errorf("failed to parse as pem and pkcs12: %w", pemErr)
+	}
+	if pkcsErr != nil {
+		return nil, fmt.Errorf("failed to parse as pem and pkcs12: %w", pkcsErr)
+	}
+	return nil, fmt.Errorf("failed to parse as pem and pkcs12")
+}
+
+// looksLikePKCS12 reports whether data might be a PKCS#12/PFX binary.
+// PKCS#12 is an ASN.1 SEQUENCE (tag 0x30); PEM text never starts that way.
+func looksLikePKCS12(data []byte) bool {
+	return len(data) > 0 && data[0] == 0x30
 }
 
 func getCertificateMetrics(cert *x509.Certificate) certMetric {

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -17,7 +17,9 @@ var (
 		},
 	)
 
-	// Discovered is a prometheus guage that indicates the sum of discovered certificates after taking into account include and exclude globs
+	// Discovered is a prometheus gauge for the number of files matched by
+	// include/exclude globs across all file-based checkers (certs, kubeconfigs).
+	// Concurrent checkers adjust it by delta rather than overwriting.
 	Discovered = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,

--- a/test/files/genCerts.sh
+++ b/test/files/genCerts.sh
@@ -41,7 +41,7 @@ openssl x509 -req -in bundle_server.csr -CA bundle_root.cert -CAkey bundle_root.
 # create bundle
 cat bundle_server.cert bundle_root.cert > bundle.crt
 
-# generate pfx 
-openssl pkcs12 -export -out bundle_pfx.crt -in bundle.crt -inkey bundle_root.key -passout pass:
+# generate pfx (leaf key must match first cert in the bundle)
+openssl pkcs12 -export -out bundle_pfx.crt -in bundle.crt -inkey bundle_server.key -passout pass:
 
 popd

--- a/test/files/test.sh
+++ b/test/files/test.sh
@@ -20,13 +20,50 @@ fetchMetrics() {
     curl --silent http://localhost:8080/metrics
 }
 
+# assertMetricLine fails the script with a clear message when a metrics line is missing.
+# Bare `grep` under `set -e` exits silently on no match — never use that for assertions.
+# Retries briefly so concurrent checkers can finish updating shared gauges.
+assertMetricLine() {
+    local needle
+    local metrics
+    local match
+    local i
+    needle="$1"
+    metrics="${2:-}"
+
+    for i in $(seq 1 20); do
+        if [ -z "$metrics" ] || [ "$i" -gt 1 ]; then
+            metrics=$(fetchMetrics)
+        fi
+
+        # Prefer an exact sample line (not HELP/TYPE comments).
+        match=$(printf '%s\n' "$metrics" | grep -E "^${needle}([[:space:]]|$)" || true)
+        if [ -z "$match" ]; then
+            match=$(printf '%s\n' "$metrics" | grep -F "$needle" || true)
+        fi
+
+        if [ -n "$match" ]; then
+            echo "TEST SUCCESS: $match"
+            return 0
+        fi
+        sleep 0.1
+    done
+
+    echo "TEST FAILURE: missing metrics line matching: $needle"
+    echo "  Relevant metrics output:"
+    printf '%s\n' "$metrics" | grep -E '^(cert_exporter_discovered|cert_exporter_error_total|# HELP cert_exporter_discovered|# HELP cert_exporter_error_total)' || true
+    echo "  Full metrics dump follows:"
+    printf '%s\n' "$metrics"
+    exit 1
+}
+
 fetchMetricsTimestampValue() {
     local metrics
     metrics="$1"
 
     curl --silent http://localhost:8080/metrics \
     | grep -F "$metrics" \
-    | awk '{ printf("%.0f",$2) }'
+    | awk '{ printf("%.0f",$2) }' || true
 }
 
 validateTimestampBefore() {
@@ -55,10 +92,14 @@ validateTimestampBefore() {
 validateMetrics() {
     local metrics
     local expectedVal
+    local raw
+    local val
+    local valInDays
     metrics=$1
     expectedVal=$2
 
-    raw=$(curl --silent http://localhost:8080/metrics | grep "$metrics")
+    # grep returns 1 when there is no match; do not trip set -e
+    raw=$(curl --silent http://localhost:8080/metrics | grep "$metrics" || true)
 
     if [ "$raw" == "" ]; then
       echo "TEST FAILURE: $metrics" 
@@ -67,7 +108,7 @@ validateMetrics() {
     fi
 
     val=${raw#* }
-    valInDays=$(awk "BEGIN {print $val / (24 * 60 * 60)}")
+    valInDays=$(awk "BEGIN {printf \"%.0f\", $val / (24 * 60 * 60)}")
 
     if [ "$expectedVal" -ne "$valInDays" ]; then
       echo "TEST FAILURE: $metrics"
@@ -83,10 +124,49 @@ validateMetrics() {
 # cleanup certs
 ./testCleanup.sh
 
-CERT_EXPORTER_PATH="../../dist/cert-exporter_$(go env GOOS)_$(go env GOARCH)_v1/cert-exporter"
+# Resolve the goreleaser binary path. amd64 builds use a microarchitecture
+# suffix (_v1); arm64 often does not. Prefer the conventional _v1 path, then
+# fall back to the unsuffixed layout.
+resolve_cert_exporter() {
+    local os arch base
+    os="$(go env GOOS)"
+    arch="$(go env GOARCH)"
+    base="../../dist"
+    for candidate in \
+        "${base}/cert-exporter_${os}_${arch}_v1/cert-exporter" \
+        "${base}/cert-exporter_${os}_${arch}/cert-exporter"
+    do
+        if [ -x "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    echo "ERROR: cert-exporter binary not found under ${base}/cert-exporter_${os}_${arch}*/" >&2
+    ls -la "${base}" 2>/dev/null || true
+    return 1
+}
+
+stop_exporter() {
+    local pid=$1
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" 2>/dev/null || true
+        # Wait for the process (and :8080) to go away so the next run can bind
+        for _ in $(seq 1 20); do
+            if ! kill -0 "$pid" 2>/dev/null; then
+                break
+            fi
+            sleep 0.1
+        done
+        kill -9 "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    fi
+}
+
+CERT_EXPORTER_PATH="$(resolve_cert_exporter)"
 
 days=${1:-100}
 export NODE_NAME="master0"
+exporter_pid=""
 
 #
 # certs and kubeconfig in the same dir
@@ -99,12 +179,14 @@ mkdir certs
 
 # run exporter
 $CERT_EXPORTER_PATH -include-cert-glob=certs/*.crt  -include-kubeconfig-glob=certs/kubeconfig &
+exporter_pid=$!
 
 waitForMetrics
 
+# 5 cert files (*.crt) + 1 kubeconfig file; concurrent checkers accumulate.
 metrics=$(fetchMetrics)
-echo "$metrics" | grep 'cert_exporter_discovered 5'
-echo "$metrics" | grep 'cert_exporter_error_total 0'
+assertMetricLine 'cert_exporter_discovered 6' "$metrics"
+assertMetricLine 'cert_exporter_error_total 0' "$metrics"
 
 activation=$(date +%s) # this timestamp is at least 2 seconds off from the actual cert NotBefore attribute ...
 validateTimestampBefore 'cert_exporter_cert_not_before_timestamp{cn="client",filename="certs/client.crt",issuer="root",nodename="master0"}' $activation
@@ -136,10 +218,10 @@ validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{cn="client",filenam
 validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{cn="client",filename="certs/kubeconfig",issuer="root",name="user2",nodename="master0",type="user"}' $days
 
 # kill exporter
-kill $!
+stop_exporter "$exporter_pid"
 
 #
-# certs and kubeconfig in the same dir
+# certs and kubeconfig in sibling dirs
 #
 echo "** Testing Certs and kubeconfig in sibling dirs"
 mkdir certsSibling
@@ -149,15 +231,19 @@ mkdir kubeConfigSibling
 
 # run exporter
 $CERT_EXPORTER_PATH -include-cert-glob=certsSibling/*.crt  -include-kubeconfig-glob=kubeConfigSibling/kubeconfig &
+exporter_pid=$!
 
 waitForMetrics
 
-echo "$(fetchMetrics)" | grep 'cert_exporter_error_total 0'
+# 5 cert files + 1 kubeconfig (sibling layout)
+metrics=$(fetchMetrics)
+assertMetricLine 'cert_exporter_discovered 6' "$metrics"
+assertMetricLine 'cert_exporter_error_total 0' "$metrics"
 
 activation=$(date +%s) # this timestamp is at least 2 seconds off from the actual cert NotBefore attribute ...
-validateTimestampBefore 'cert_exporter_cert_not_after_timestamp{cn="client",filename="certsSibling/client.crt",issuer="root",nodename="master0"}' $activation
-validateTimestampBefore 'cert_exporter_cert_not_after_timestamp{cn="root",filename="certsSibling/root.crt",issuer="root",nodename="master0"}' $activation
-validateTimestampBefore 'cert_exporter_cert_not_after_timestamp{cn="example.com",filename="certsSibling/server.crt",issuer="root",nodename="master0"}' $activation
+validateTimestampBefore 'cert_exporter_cert_not_before_timestamp{cn="client",filename="certsSibling/client.crt",issuer="root",nodename="master0"}' $activation
+validateTimestampBefore 'cert_exporter_cert_not_before_timestamp{cn="root",filename="certsSibling/root.crt",issuer="root",nodename="master0"}' $activation
+validateTimestampBefore 'cert_exporter_cert_not_before_timestamp{cn="example.com",filename="certsSibling/server.crt",issuer="root",nodename="master0"}' $activation
 
 expiration=$((activation + days * 24 * 60 * 60)) # ... and as a result, this values if off as well
 validateTimestampBefore 'cert_exporter_cert_not_after_timestamp{cn="client",filename="certsSibling/client.crt",issuer="root",nodename="master0"}' $expiration
@@ -174,7 +260,7 @@ validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{cn="client",filenam
 validateMetrics 'cert_exporter_kubeconfig_expires_in_seconds{cn="client",filename="kubeConfigSibling/kubeconfig",issuer="root",name="user2",nodename="master0",type="user"}' $days
 
 # kill exporter
-kill $!
+stop_exporter "$exporter_pid"
 
 #
 # confirm error metric works
@@ -184,11 +270,13 @@ echo 'asdfasdf' > certs/client.crt
 
 # run exporter
 $CERT_EXPORTER_PATH -include-cert-glob=certs/client.crt &
+exporter_pid=$!
 
 waitForMetrics
 
-echo "$(fetchMetrics)" | grep 'cert_exporter_error_total 1'
+assertMetricLine 'cert_exporter_error_total 1'
+assertMetricLine 'cert_exporter_discovered 1'
 
 # kill exporter
-kill $!
+stop_exporter "$exporter_pid"
 unset NODE_NAME


### PR DESCRIPTION
Should allow us to close #247 & #246 

Bump `actions/checkout` to v7, `docker/metadata-action` to v6.1.0, Go to 1.26.5, and alpine to 3.24