### PR TITLE
feat: add serial label to certificate metrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   release:
+    # chart-releaser creates GitHub Releases and pushes index.yaml to gh-pages
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,6 +35,12 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      # chart-releaser always does `git worktree add … origin/gh-pages` during
+      # `cr upload` / `cr index`. actions/checkout only fetches the push ref,
+      # so origin/gh-pages is missing unless we fetch it explicitly.
+      - name: Fetch gh-pages
+        run: git fetch origin gh-pages:refs/remotes/origin/gh-pages
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0

--- a/integration_test.go
+++ b/integration_test.go
@@ -17,7 +17,7 @@ import (
 // TestEndToEnd tests the complete flow of cert-exporter with certificates on disk
 func TestEndToEnd_FileBasedCerts(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(false, testRegistry)
+	metrics.Init(false, testRegistry, false)
 
 	tmpDir := testutil.CreateTempCertDir(t)
 
@@ -141,7 +141,7 @@ func TestEndToEnd_FileBasedCerts(t *testing.T) {
 // TestEndToEnd_Kubeconfig tests kubeconfig parsing and metric export
 func TestEndToEnd_Kubeconfig(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(false, testRegistry)
+	metrics.Init(false, testRegistry, false)
 
 	tmpDir := testutil.CreateTempCertDir(t)
 	certDir := filepath.Join(tmpDir, "certs")
@@ -238,7 +238,7 @@ func TestEndToEnd_Kubeconfig(t *testing.T) {
 // TestEndToEnd_ErrorMetric tests that error metrics are properly incremented
 func TestEndToEnd_ErrorMetric(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(false, testRegistry)
+	metrics.Init(false, testRegistry, false)
 
 	tmpDir := testutil.CreateTempCertDir(t)
 

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ var (
 	certRequestsNamespace             string
 	certRequestsListOfNamespaces      string
 	deprecatedLogtostderr             bool
+	includeSerialLabel          bool
 )
 
 func init() {
@@ -109,11 +110,12 @@ func init() {
 	flag.StringVar(&certRequestsListOfNamespaces, "certrequests-namespaces", "", "Kubernetes comma-delimited list of namespaces to search for certrequests.")
 
 	flag.BoolVar(&deprecatedLogtostderr, "logtostderr", true, "DEPRECATED: This flag is no longer used. Logs are always written to stderr.")
+	flag.BoolVar(&includeSerialLabel, "include-serial-label", false, "Add serial label to certificate metrics (disambiguates multi-PEM bundles).")
 }
 
 func main() {
 	flag.Parse()
-	metrics.Init(prometheusExporterMetricsDisabled, nil)
+	metrics.Init(prometheusExporterMetricsDisabled, nil, includeSerialLabel)
 
 	// Check if --logtostderr was explicitly set
 	flag.Visit(func(f *flag.Flag) {

--- a/readme.md
+++ b/readme.md
@@ -60,11 +60,11 @@ cert_exporter_error_total 0
 cert_exporter_discovered 0
 # HELP cert_exporter_cert_expires_in_seconds Number of seconds til the cert expires.
 # TYPE cert_exporter_cert_expires_in_seconds gauge
-cert_exporter_cert_expires_in_seconds{filename="certsSibling/client.crt",issuer="root",nodename="master0"} 8.639964560021e+06
+cert_exporter_cert_expires_in_seconds{cn="client",filename="certsSibling/client.crt",issuer="root",nodename="master0"} 8.639964560021e+06
 # HELP cert_exporter_kubeconfig_expires_in_seconds Number of seconds til the cert in kubeconfig expires.
 # TYPE cert_exporter_kubeconfig_expires_in_seconds gauge
-cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="cluster1",nodename="master0",type="cluster"} 8.639964559682e+06
-cert_exporter_kubeconfig_expires_in_seconds{filename="kubeConfigSibling/kubeconfig",name="user1",nodename="master0",type="user"} 8.639964559249e+06
+cert_exporter_kubeconfig_expires_in_seconds{cn="root",filename="kubeConfigSibling/kubeconfig",issuer="root",name="cluster1",nodename="master0",type="cluster"} 8.639964559682e+06
+cert_exporter_kubeconfig_expires_in_seconds{cn="client",filename="kubeConfigSibling/kubeconfig",issuer="root",name="user1",nodename="master0",type="user"} 8.639964559249e+06
 # HELP cert_exporter_secret_expires_in_seconds Number of seconds til the cert in the secret expires.
 # TYPE cert_exporter_secret_expires_in_seconds gauge
 cert_exporter_secret_expires_in_seconds{cn="example.com",issuer="example.com",key_name="ca.crt",secret_name="selfsigned-cert-tls",secret_namespace="cert-manager-test"} 8.6396867095666e+06
@@ -86,23 +86,35 @@ The number of files matched by include/exclude globs across all file-based check
 **cert_exporter_error_total**  
 The total number of unexpected errors encountered by cert-exporter.  A good metric to watch to feel comfortable certs are being exported properly.
 
+**`--include-serial-label` (optional)**  
+Default **false** (no series identity change). When **true**, every certificate metric gains a `serial` label (lowercase hex). Enable this when a single file/secret/configmap key holds multiple PEMs that share the same `cn`/`issuer`, otherwise Prometheus collapses them into one series. Enabling this will cause churn, so check your dashboards and alerts beforehand.
+
+Example with the flag on:
+
+```
+cert_exporter_secret_expires_in_seconds{cn="service-ca",issuer="service-ca",key_name="service-ca.crt",secret_name="…",secret_namespace="…",serial="a1b2c3"} …
+cert_exporter_secret_expires_in_seconds{cn="service-ca",issuer="service-ca",key_name="service-ca.crt",secret_name="…",secret_namespace="…",serial="d4e5f6"} …
+```
+
 **cert_exporter_cert_expires_in_seconds**  
-The number of seconds until a certificate stored in the PEM format is expired.  The `filename`, `issuer`, `cn`, and `nodename` label indicates the exported cert.
+The number of seconds until a certificate stored in the PEM format is expired.  The `filename`, `issuer`, `cn`, and `nodename` labels indicate the exported cert (`serial` when enabled).
 
 **cert_exporter_kubeconfig_expires_in_seconds**  
-The number of seconds until a certificate stored in a kubeconfig expires.  The `filename`, `type`, `name`, and `nodename` labels indicate the kubeconfig, cluster or user node and name of the node.  See details [here](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
+The number of seconds until a certificate stored in a kubeconfig expires.  The `filename`, `type`, `name`, and `nodename` labels indicate the kubeconfig, cluster or user node and name of the node (`serial` when enabled).  See details [here](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
 
 **cert_exporter_secret_expires_in_seconds**
-The number of seconds until a certificate stored in a kubernetes secret expires.  The `key_name`, `issuer`, `cn`, `secret_name`, and `secret_namespace` labels indicate the secret key, name and namespace. 
+The number of seconds until a certificate stored in a kubernetes secret expires.  The `key_name`, `issuer`, `cn`, `secret_name`, and `secret_namespace` labels indicate the secret key, name and namespace (`serial` when enabled).
 
 **cert_exporter_certrequest_expires_in_seconds**
-The number of seconds until a certificate stored in a cert-manager CertificateRequest expires.  The `cert_request`, `issuer`, `cn`, and `certrequest_namespace` labels indicate the CertificateRequest, comon name and namespace. 
+The number of seconds until a certificate stored in a cert-manager CertificateRequest expires.  The `cert_request`, `issuer`, `cn`, and `certrequest_namespace` labels indicate the CertificateRequest, common name and namespace (`serial` when enabled).
 
 **cert_exporter_certrequest_not_after_timestamp**
-The timestamp when a certificate stored in a cert-manager CertificateRequest expires.   The `cert_request`, `issuer`, `cn`, and `certrequest_namespace` labels indicate the CertificateRequest, comon name and namespace. 
+The timestamp when a certificate stored in a cert-manager CertificateRequest expires.   The `cert_request`, `issuer`, `cn`, and `certrequest_namespace` labels indicate the CertificateRequest, common name and namespace (`serial` when enabled).
 
 **cert_exporter_certrequest_not_before_timestamp**
-The timestamp when a certificate stored in a cert-manager CertificateRequest becomes valid.   The `cert_request`, `issuer`, `cn`, and `certrequest_namespace` labels indicate the CertificateRequest, comon name and namespace. 
+The timestamp when a certificate stored in a cert-manager CertificateRequest becomes valid.   The `cert_request`, `issuer`, `cn`, and `certrequest_namespace` labels indicate the CertificateRequest, common name and namespace (`serial` when enabled).
+
+
 
 ### Other Docs
 

--- a/src/checkers/periodicAwsChecker_test.go
+++ b/src/checkers/periodicAwsChecker_test.go
@@ -110,7 +110,7 @@ func TestNewAwsChecker_MultipleSecrets(t *testing.T) {
 
 func TestPeriodicAwsChecker_ProcessSecret_Success(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -183,7 +183,7 @@ func TestPeriodicAwsChecker_ProcessSecret_Success(t *testing.T) {
 
 func TestPeriodicAwsChecker_ProcessSecret_RawPEM(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -250,7 +250,7 @@ func TestPeriodicAwsChecker_ProcessSecret_RawPEM(t *testing.T) {
 
 func TestPeriodicAwsChecker_ProcessSecret_KeyFiltering(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -374,7 +374,7 @@ func TestPeriodicAwsChecker_ProcessSecret_InvalidJSON(t *testing.T) {
 
 func TestPeriodicAwsChecker_CheckSecrets_MultipleSecrets(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificates
 	cert1 := testutil.GenerateCertificate(t, testutil.CertConfig{

--- a/src/checkers/periodicCertChecker_test.go
+++ b/src/checkers/periodicCertChecker_test.go
@@ -116,7 +116,7 @@ func TestPeriodicCertChecker_GetMatches(t *testing.T) {
 
 func TestPeriodicCertChecker_StartChecking(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	tmpDir := testutil.CreateTempCertDir(t)
 
@@ -163,7 +163,7 @@ func TestPeriodicCertChecker_StartChecking(t *testing.T) {
 
 func TestPeriodicCertChecker_DiscoveredAccumulation(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 	// Discovered is a process-global gauge; zero it so this test is isolated.
 	metrics.Discovered.Set(0)
 
@@ -233,7 +233,7 @@ func gatherDiscovered(t *testing.T, reg *prometheus.Registry) float64 {
 
 func TestPeriodicCertChecker_ErrorHandling(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Capture error_total before this test; the counter is process-global.
 	var errorCountBefore float64

--- a/src/exporters/awsExporter.go
+++ b/src/exporters/awsExporter.go
@@ -16,7 +16,8 @@ func (c *AwsExporter) ExportMetrics(file, secretName, key string) error {
 	}
 
 	for _, metric := range metricCollection {
-		metrics.AwsCertExpirySeconds.WithLabelValues(secretName, key, file, metric.issuer, metric.cn).Set(metric.durationUntilExpiry)
+		labels := metrics.AppendSerial([]string{secretName, key, file, metric.issuer, metric.cn}, metric.serial)
+		metrics.AwsCertExpirySeconds.WithLabelValues(labels...).Set(metric.durationUntilExpiry)
 	}
 
 	return nil

--- a/src/exporters/awsExporter_test.go
+++ b/src/exporters/awsExporter_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAwsExporter_ExportMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -64,7 +64,7 @@ func TestAwsExporter_ExportMetrics(t *testing.T) {
 
 func TestAwsExporter_ExportMetrics_InvalidBase64(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	exporter := &AwsExporter{}
 	exporter.ResetMetrics()
@@ -78,7 +78,7 @@ func TestAwsExporter_ExportMetrics_InvalidBase64(t *testing.T) {
 
 func TestAwsExporter_ExportMetrics_InvalidCertificate(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	exporter := &AwsExporter{}
 	exporter.ResetMetrics()
@@ -93,7 +93,7 @@ func TestAwsExporter_ExportMetrics_InvalidCertificate(t *testing.T) {
 
 func TestAwsExporter_ResetMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate and export test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -149,7 +149,7 @@ func TestAwsExporter_ResetMetrics(t *testing.T) {
 
 func TestAwsExporter_MultipleSecrets(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate multiple certificates
 	cert1 := testutil.GenerateCertificate(t, testutil.CertConfig{

--- a/src/exporters/certExporter.go
+++ b/src/exporters/certExporter.go
@@ -16,9 +16,10 @@ func (c *CertExporter) ExportMetrics(file, nodeName string) error {
 	}
 
 	for _, metric := range metricCollection {
-		metrics.CertExpirySeconds.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.durationUntilExpiry)
-		metrics.CertNotAfterTimestamp.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.notAfter)
-		metrics.CertNotBeforeTimestamp.WithLabelValues(file, metric.issuer, metric.cn, nodeName).Set(metric.notBefore)
+		labels := metrics.AppendSerial([]string{file, metric.issuer, metric.cn, nodeName}, metric.serial)
+		metrics.CertExpirySeconds.WithLabelValues(labels...).Set(metric.durationUntilExpiry)
+		metrics.CertNotAfterTimestamp.WithLabelValues(labels...).Set(metric.notAfter)
+		metrics.CertNotBeforeTimestamp.WithLabelValues(labels...).Set(metric.notBefore)
 	}
 
 	return nil

--- a/src/exporters/certExporter_test.go
+++ b/src/exporters/certExporter_test.go
@@ -2,6 +2,7 @@ package exporters
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,10 +12,59 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
+// TestCertExporter_SameCNDifferentSerial ensures file-based multi-PEM bundles
+// with identical cn/issuer keep distinct series via serial.
+func TestCertExporter_SameCNDifferentSerial(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	metrics.Init(true, testRegistry, true)
+
+	tmpDir := t.TempDir()
+	certFile := filepath.Join(tmpDir, "service-ca.crt")
+
+	newer := testutil.GenerateCertificate(t, testutil.CertConfig{
+		CommonName: "service-ca", Organization: "org", Country: "US", Province: "CA", Days: 365, IsCA: true,
+	})
+	older := testutil.GenerateCertificate(t, testutil.CertConfig{
+		CommonName: "service-ca", Organization: "org", Country: "US", Province: "CA", Days: 30, IsCA: true,
+	})
+	testutil.WriteCertToFile(t, testutil.CreateCertBundle(newer, older), certFile)
+
+	exporter := &CertExporter{}
+	exporter.ResetMetrics()
+	if err := exporter.ExportMetrics(certFile, "node1"); err != nil {
+		t.Fatalf("ExportMetrics: %v", err)
+	}
+
+	mfs, err := testRegistry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	serials := map[string]struct{}{}
+	for _, mf := range mfs {
+		if mf.GetName() != "cert_exporter_cert_expires_in_seconds" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			labels := getLabelMap(metric)
+			if labels["filename"] != certFile || labels["cn"] != "service-ca" {
+				continue
+			}
+			if labels["serial"] == "" {
+				t.Error("expected serial label")
+			}
+			serials[labels["serial"]] = struct{}{}
+		}
+	}
+	if len(serials) != 2 {
+		t.Fatalf("expected 2 series, got %d: %v", len(serials), serials)
+	}
+}
+
 func TestCertExporter_ExportMetrics(t *testing.T) {
 	// Create a custom registry for this test to avoid collisions
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	tests := []struct {
 		name     string
@@ -153,7 +203,7 @@ func TestCertExporter_ExportMetrics(t *testing.T) {
 func TestCertExporter_MetricsValues(t *testing.T) {
 	// Create a custom registry for this test to avoid collisions
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	tmpDir := testutil.CreateTempCertDir(t)
 	certFile := tmpDir + "/test.crt"
@@ -227,7 +277,7 @@ func TestCertExporter_MetricsValues(t *testing.T) {
 func TestCertExporter_PKCS12(t *testing.T) {
 	// Create a custom registry for this test to avoid collisions
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	tmpDir := testutil.CreateTempCertDir(t)
 	certFile := tmpDir + "/test.p12"
@@ -290,7 +340,7 @@ func TestCertExporter_PKCS12(t *testing.T) {
 func TestCertExporter_ResetMetrics(t *testing.T) {
 	// Create a custom registry for this test to avoid collisions
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	tmpDir := testutil.CreateTempCertDir(t)
 	certFile := tmpDir + "/test.crt"

--- a/src/exporters/certHelpers.go
+++ b/src/exporters/certHelpers.go
@@ -18,6 +18,10 @@ type certMetric struct {
 	notAfter, notBefore float64
 	issuer              string
 	cn                  string
+	// serial is the certificate serial number in lowercase hex. Used as a
+	// Prometheus label so multiple PEMs that share cn/issuer (e.g. rotated
+	// service-CA bundles) do not overwrite one another.
+	serial string
 }
 
 func secondsToExpiryFromCertAsFile(file string) ([]certMetric, error) {
@@ -74,6 +78,9 @@ func getCertificateMetrics(cert *x509.Certificate) certMetric {
 	metric.durationUntilExpiry = time.Until(cert.NotAfter).Seconds()
 	metric.issuer = cert.Issuer.CommonName
 	metric.cn = cert.Subject.CommonName
+	if cert.SerialNumber != nil {
+		metric.serial = cert.SerialNumber.Text(16)
+	}
 	return metric
 }
 

--- a/src/exporters/certHelpers_test.go
+++ b/src/exporters/certHelpers_test.go
@@ -186,6 +186,9 @@ func TestParseAsPEM(t *testing.T) {
 					if metric.notAfter == 0 {
 						t.Errorf("metric[%d] notAfter should not be zero", i)
 					}
+					if metric.serial == "" {
+						t.Errorf("metric[%d] serial should not be empty", i)
+					}
 				}
 			}
 		})

--- a/src/exporters/certRequestExporter.go
+++ b/src/exporters/certRequestExporter.go
@@ -16,9 +16,10 @@ func (c *CertRequestExporter) ExportMetrics(bytes []byte, certrequest, certreque
 	}
 
 	for _, metric := range metricCollection {
-		metrics.CertRequestExpirySeconds.WithLabelValues(metric.issuer, metric.cn, certrequest, certrequestNamespace).Set(metric.durationUntilExpiry)
-		metrics.CertRequestNotAfterTimestamp.WithLabelValues(metric.issuer, metric.cn, certrequest, certrequestNamespace).Set(metric.notAfter)
-		metrics.CertRequestNotBeforeTimestamp.WithLabelValues(metric.issuer, metric.cn, certrequest, certrequestNamespace).Set(metric.notBefore)
+		labels := metrics.AppendSerial([]string{metric.issuer, metric.cn, certrequest, certrequestNamespace}, metric.serial)
+		metrics.CertRequestExpirySeconds.WithLabelValues(labels...).Set(metric.durationUntilExpiry)
+		metrics.CertRequestNotAfterTimestamp.WithLabelValues(labels...).Set(metric.notAfter)
+		metrics.CertRequestNotBeforeTimestamp.WithLabelValues(labels...).Set(metric.notBefore)
 	}
 
 	return nil

--- a/src/exporters/certRequestExporter_test.go
+++ b/src/exporters/certRequestExporter_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCertRequestExporter_ExportMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -85,7 +85,7 @@ func TestCertRequestExporter_ExportMetrics(t *testing.T) {
 
 func TestCertRequestExporter_ExportMetrics_Bundle(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate CA and signed cert
 	caCert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -153,7 +153,7 @@ func TestCertRequestExporter_ExportMetrics_Bundle(t *testing.T) {
 
 func TestCertRequestExporter_ExportMetrics_MultipleNamespaces(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificates
 	cert1 := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -211,7 +211,7 @@ func TestCertRequestExporter_ExportMetrics_MultipleNamespaces(t *testing.T) {
 
 func TestCertRequestExporter_ExportMetrics_InvalidCert(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	exporter := &CertRequestExporter{}
 	exporter.ResetMetrics()
@@ -225,7 +225,7 @@ func TestCertRequestExporter_ExportMetrics_InvalidCert(t *testing.T) {
 
 func TestCertRequestExporter_ResetMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate and export test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -279,7 +279,7 @@ func TestCertRequestExporter_ResetMetrics(t *testing.T) {
 
 func TestCertRequestExporter_LabelValues(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate with specific issuer
 	caCert := testutil.GenerateCertificate(t, testutil.CertConfig{

--- a/src/exporters/configMapExporter.go
+++ b/src/exporters/configMapExporter.go
@@ -16,9 +16,10 @@ func (c *ConfigMapExporter) ExportMetrics(bytes []byte, keyName, configMapName, 
 	}
 
 	for _, metric := range metricCollection {
-		metrics.ConfigMapExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace).Set(metric.durationUntilExpiry)
-		metrics.ConfigMapNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace).Set(metric.notAfter)
-		metrics.ConfigMapNotBeforeTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace).Set(metric.notBefore)
+		labels := metrics.AppendSerial([]string{keyName, metric.issuer, metric.cn, configMapName, configMapNamespace}, metric.serial)
+		metrics.ConfigMapExpirySeconds.WithLabelValues(labels...).Set(metric.durationUntilExpiry)
+		metrics.ConfigMapNotAfterTimestamp.WithLabelValues(labels...).Set(metric.notAfter)
+		metrics.ConfigMapNotBeforeTimestamp.WithLabelValues(labels...).Set(metric.notBefore)
 	}
 
 	return nil

--- a/src/exporters/configMapExporter_test.go
+++ b/src/exporters/configMapExporter_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestConfigMapExporter_ExportMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -82,9 +82,52 @@ func TestConfigMapExporter_ExportMetrics(t *testing.T) {
 	}
 }
 
+// TestConfigMapExporter_SameCNDifferentSerial covers rotated CA bundles in a
+// configmap key (e.g. OpenShift service-ca.crt) where cn/issuer collide.
+func TestConfigMapExporter_SameCNDifferentSerial(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	metrics.Init(true, testRegistry, true)
+
+	newer := testutil.GenerateCertificate(t, testutil.CertConfig{
+		CommonName: "service-ca", Organization: "org", Country: "US", Province: "CA", Days: 365, IsCA: true,
+	})
+	older := testutil.GenerateCertificate(t, testutil.CertConfig{
+		CommonName: "service-ca", Organization: "org", Country: "US", Province: "CA", Days: 30, IsCA: true,
+	})
+	bundle := testutil.CreateCertBundle(newer, older)
+
+	exporter := &ConfigMapExporter{}
+	exporter.ResetMetrics()
+	if err := exporter.ExportMetrics(bundle, "service-ca.crt", "service-ca", "openshift-config"); err != nil {
+		t.Fatalf("ExportMetrics: %v", err)
+	}
+
+	mfs, err := testRegistry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	serials := map[string]float64{}
+	for _, mf := range mfs {
+		if mf.GetName() != "cert_exporter_configmap_expires_in_seconds" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			labels := getLabelMap(metric)
+			if labels["configmap_name"] != "service-ca" || labels["cn"] != "service-ca" {
+				continue
+			}
+			serials[labels["serial"]] = metric.GetGauge().GetValue()
+		}
+	}
+	if len(serials) != 2 {
+		t.Fatalf("expected 2 series for same-CN configmap bundle, got %d: %v", len(serials), serials)
+	}
+}
+
 func TestConfigMapExporter_ExportMetrics_Bundle(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate CA and intermediate cert
 	caCert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -152,7 +195,7 @@ func TestConfigMapExporter_ExportMetrics_Bundle(t *testing.T) {
 
 func TestConfigMapExporter_ExportMetrics_MultipleKeys(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate multiple certificates
 	cert1 := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -212,7 +255,7 @@ func TestConfigMapExporter_ExportMetrics_MultipleKeys(t *testing.T) {
 
 func TestConfigMapExporter_ExportMetrics_InvalidCert(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	exporter := &ConfigMapExporter{}
 	exporter.ResetMetrics()
@@ -226,7 +269,7 @@ func TestConfigMapExporter_ExportMetrics_InvalidCert(t *testing.T) {
 
 func TestConfigMapExporter_ResetMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate and export test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -280,7 +323,7 @@ func TestConfigMapExporter_ResetMetrics(t *testing.T) {
 
 func TestConfigMapExporter_LabelValues(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate with specific fields
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{

--- a/src/exporters/kubeConfigExporter.go
+++ b/src/exporters/kubeConfigExporter.go
@@ -41,9 +41,10 @@ func (c *KubeConfigExporter) ExportMetrics(file, nodeName string) error {
 		}
 
 		for _, metric := range metricCollection {
-			metrics.KubeConfigExpirySeconds.WithLabelValues(file, "cluster", metric.cn, metric.issuer, c.Name, nodeName).Set(metric.durationUntilExpiry)
-			metrics.KubeConfigNotAfterTimestamp.WithLabelValues(file, "cluster", metric.cn, metric.issuer, c.Name, nodeName).Set(metric.notAfter)
-			metrics.KubeConfigNotBeforeTimestamp.WithLabelValues(file, "cluster", metric.cn, metric.issuer, c.Name, nodeName).Set(metric.notBefore)
+			labels := metrics.AppendSerial([]string{file, "cluster", metric.cn, metric.issuer, c.Name, nodeName}, metric.serial)
+			metrics.KubeConfigExpirySeconds.WithLabelValues(labels...).Set(metric.durationUntilExpiry)
+			metrics.KubeConfigNotAfterTimestamp.WithLabelValues(labels...).Set(metric.notAfter)
+			metrics.KubeConfigNotBeforeTimestamp.WithLabelValues(labels...).Set(metric.notBefore)
 		}
 	}
 
@@ -68,9 +69,10 @@ func (c *KubeConfigExporter) ExportMetrics(file, nodeName string) error {
 		}
 
 		for _, metric := range metricCollection {
-			metrics.KubeConfigExpirySeconds.WithLabelValues(file, "user", metric.cn, metric.issuer, u.Name, nodeName).Set(metric.durationUntilExpiry)
-			metrics.KubeConfigNotAfterTimestamp.WithLabelValues(file, "user", metric.cn, metric.issuer, u.Name, nodeName).Set(metric.notAfter)
-			metrics.KubeConfigNotBeforeTimestamp.WithLabelValues(file, "user", metric.cn, metric.issuer, u.Name, nodeName).Set(metric.notBefore)
+			labels := metrics.AppendSerial([]string{file, "user", metric.cn, metric.issuer, u.Name, nodeName}, metric.serial)
+			metrics.KubeConfigExpirySeconds.WithLabelValues(labels...).Set(metric.durationUntilExpiry)
+			metrics.KubeConfigNotAfterTimestamp.WithLabelValues(labels...).Set(metric.notAfter)
+			metrics.KubeConfigNotBeforeTimestamp.WithLabelValues(labels...).Set(metric.notBefore)
 		}
 	}
 

--- a/src/exporters/kubeConfigExporter_test.go
+++ b/src/exporters/kubeConfigExporter_test.go
@@ -13,9 +13,9 @@ import (
 func TestKubeConfigExporter_ExportMetrics(t *testing.T) {
 	// Create a custom registry for this test to avoid collisions
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
-	tests := []struct{
+	tests := []struct {
 		name     string
 		setup    func(t *testing.T) string
 		nodeName string
@@ -231,7 +231,7 @@ func TestKubeConfigExporter_ExportMetrics(t *testing.T) {
 func TestKubeConfigExporter_MetricsLabels(t *testing.T) {
 	// Create a custom registry for this test to avoid collisions
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	tmpDir := testutil.CreateTempCertDir(t)
 	kubeConfigFile := filepath.Join(tmpDir, "kubeconfig")

--- a/src/exporters/secretExporter.go
+++ b/src/exporters/secretExporter.go
@@ -16,9 +16,10 @@ func (c *SecretExporter) ExportMetrics(bytes []byte, keyName, secretName, secret
 	}
 
 	for _, metric := range metricCollection {
-		metrics.SecretExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.durationUntilExpiry)
-		metrics.SecretNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.notAfter)
-		metrics.SecretNotBeforeTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.notBefore)
+		labels := metrics.AppendSerial([]string{keyName, metric.issuer, metric.cn, secretName, secretNamespace}, metric.serial)
+		metrics.SecretExpirySeconds.WithLabelValues(labels...).Set(metric.durationUntilExpiry)
+		metrics.SecretNotAfterTimestamp.WithLabelValues(labels...).Set(metric.notAfter)
+		metrics.SecretNotBeforeTimestamp.WithLabelValues(labels...).Set(metric.notBefore)
 	}
 
 	return nil

--- a/src/exporters/secretExporter_test.go
+++ b/src/exporters/secretExporter_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSecretExporter_ExportMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -84,7 +84,7 @@ func TestSecretExporter_ExportMetrics(t *testing.T) {
 
 func TestSecretExporter_ExportMetrics_Bundle(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate CA and intermediate cert
 	caCert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -150,9 +150,72 @@ func TestSecretExporter_ExportMetrics_Bundle(t *testing.T) {
 	}
 }
 
+// TestSecretExporter_SameCNDifferentSerial is the OpenShift service-CA rotation
+// case: two PEMs in one key with the same subject/issuer must produce two series.
+func TestSecretExporter_SameCNDifferentSerial(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	metrics.Init(true, testRegistry, true)
+
+	// Two self-signed certs with identical CN (issuer == subject CN).
+	newer := testutil.GenerateCertificate(t, testutil.CertConfig{
+		CommonName: "service-ca", Organization: "org", Country: "US", Province: "CA", Days: 365, IsCA: true,
+	})
+	older := testutil.GenerateCertificate(t, testutil.CertConfig{
+		CommonName: "service-ca", Organization: "org", Country: "US", Province: "CA", Days: 30, IsCA: true,
+	})
+	bundle := testutil.CreateCertBundle(newer, older)
+
+	exporter := &SecretExporter{}
+	exporter.ResetMetrics()
+	if err := exporter.ExportMetrics(bundle, "service-ca.crt", "service-ca", "openshift-config", ""); err != nil {
+		t.Fatalf("ExportMetrics: %v", err)
+	}
+
+	mfs, err := testRegistry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	type series struct {
+		serial string
+		value  float64
+	}
+	var found []series
+	for _, mf := range mfs {
+		if mf.GetName() != "cert_exporter_secret_expires_in_seconds" {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			labels := getLabelMap(metric)
+			if labels["secret_name"] != "service-ca" || labels["cn"] != "service-ca" {
+				continue
+			}
+			if labels["serial"] == "" {
+				t.Error("expected non-empty serial label")
+			}
+			found = append(found, series{serial: labels["serial"], value: metric.GetGauge().GetValue()})
+		}
+	}
+
+	if len(found) != 2 {
+		t.Fatalf("expected 2 series for same-CN bundle, got %d: %+v", len(found), found)
+	}
+	if found[0].serial == found[1].serial {
+		t.Fatalf("expected distinct serial labels, both %q", found[0].serial)
+	}
+	// Distinct expiries (30d vs 365d) should not have collapsed into one value.
+	delta := found[0].value - found[1].value
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta < float64(100*24*60*60) {
+		t.Fatalf("expected ~335d gap between series values, got delta=%v series=%+v", delta, found)
+	}
+}
+
 func TestSecretExporter_ExportMetrics_PKCS12(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate certificates
 	caCert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -220,7 +283,7 @@ func TestSecretExporter_ExportMetrics_PKCS12(t *testing.T) {
 
 func TestSecretExporter_ExportMetrics_PKCS12WithPassword(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate certificates
 	caCert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -279,7 +342,7 @@ func TestSecretExporter_ExportMetrics_PKCS12WithPassword(t *testing.T) {
 
 func TestSecretExporter_ExportMetrics_InvalidCert(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	exporter := &SecretExporter{}
 	exporter.ResetMetrics()
@@ -293,7 +356,7 @@ func TestSecretExporter_ExportMetrics_InvalidCert(t *testing.T) {
 
 func TestSecretExporter_ResetMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate and export test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{

--- a/src/exporters/webhookExporter.go
+++ b/src/exporters/webhookExporter.go
@@ -16,9 +16,10 @@ func (c *WebhookExporter) ExportMetrics(bytes []byte, typeName, webhookName, adm
 	}
 
 	for _, metric := range metricCollection {
-		metrics.WebhookExpirySeconds.WithLabelValues(typeName, metric.issuer, metric.cn, webhookName, admissionReviewVersionName).Set(metric.durationUntilExpiry)
-		metrics.WebhookNotAfterTimestamp.WithLabelValues(typeName, metric.issuer, metric.cn, webhookName, admissionReviewVersionName).Set(metric.notAfter)
-		metrics.WebhookNotBeforeTimestamp.WithLabelValues(typeName, metric.issuer, metric.cn, webhookName, admissionReviewVersionName).Set(metric.notBefore)
+		labels := metrics.AppendSerial([]string{typeName, metric.issuer, metric.cn, webhookName, admissionReviewVersionName}, metric.serial)
+		metrics.WebhookExpirySeconds.WithLabelValues(labels...).Set(metric.durationUntilExpiry)
+		metrics.WebhookNotAfterTimestamp.WithLabelValues(labels...).Set(metric.notAfter)
+		metrics.WebhookNotBeforeTimestamp.WithLabelValues(labels...).Set(metric.notBefore)
 	}
 
 	return nil

--- a/src/exporters/webhookExporter_test.go
+++ b/src/exporters/webhookExporter_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestWebhookExporter_ExportMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -84,7 +84,7 @@ func TestWebhookExporter_ExportMetrics(t *testing.T) {
 
 func TestWebhookExporter_ExportMetrics_ValidatingWebhook(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -133,7 +133,7 @@ func TestWebhookExporter_ExportMetrics_ValidatingWebhook(t *testing.T) {
 
 func TestWebhookExporter_ExportMetrics_Bundle(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate CA and signed cert
 	caCert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -201,7 +201,7 @@ func TestWebhookExporter_ExportMetrics_Bundle(t *testing.T) {
 
 func TestWebhookExporter_ExportMetrics_MultipleWebhooks(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificates
 	cert1 := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -259,7 +259,7 @@ func TestWebhookExporter_ExportMetrics_MultipleWebhooks(t *testing.T) {
 
 func TestWebhookExporter_ExportMetrics_InvalidCert(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	exporter := &WebhookExporter{}
 	exporter.ResetMetrics()
@@ -273,7 +273,7 @@ func TestWebhookExporter_ExportMetrics_InvalidCert(t *testing.T) {
 
 func TestWebhookExporter_ResetMetrics(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate and export test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{
@@ -327,7 +327,7 @@ func TestWebhookExporter_ResetMetrics(t *testing.T) {
 
 func TestWebhookExporter_LabelValues(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
-	metrics.Init(true, testRegistry)
+	metrics.Init(true, testRegistry, false)
 
 	// Generate test certificate
 	cert := testutil.GenerateCertificate(t, testutil.CertConfig{

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -1,11 +1,31 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
-import versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
+)
 
 const (
 	namespace = "cert_exporter"
 )
+
+// serialLabelEnabled is set by Init. When true, certificate metric families
+// include a serial label so multi-PEM bundles with the same cn/issuer
+// do not collapse into one Prometheus series.
+var serialLabelEnabled bool
+
+// SerialLabelEnabled reports whether certificate metrics include serial.
+func SerialLabelEnabled() bool {
+	return serialLabelEnabled
+}
+
+// AppendSerial appends serial to label values when the serial label is enabled.
+func AppendSerial(labelValues []string, serial string) []string {
+	if serialLabelEnabled {
+		return append(labelValues, serial)
+	}
+	return labelValues
+}
 
 var (
 	// ErrorTotal is a prometheus counter that indicates the total number of unexpected errors encountered by the application
@@ -28,201 +48,207 @@ var (
 		},
 	)
 
-	// CertExpirySeconds is a prometheus gauge that indicates the number of seconds until certificates on disk expires.
+	// Certificate metric vectors are constructed in Init so the label set can
+	// optionally include serial without a forced breaking change.
+	CertExpirySeconds             *prometheus.GaugeVec
+	CertNotAfterTimestamp         *prometheus.GaugeVec
+	CertNotBeforeTimestamp        *prometheus.GaugeVec
+	KubeConfigExpirySeconds       *prometheus.GaugeVec
+	KubeConfigNotAfterTimestamp   *prometheus.GaugeVec
+	KubeConfigNotBeforeTimestamp  *prometheus.GaugeVec
+	SecretExpirySeconds           *prometheus.GaugeVec
+	SecretNotAfterTimestamp       *prometheus.GaugeVec
+	SecretNotBeforeTimestamp      *prometheus.GaugeVec
+	CertRequestExpirySeconds      *prometheus.GaugeVec
+	CertRequestNotAfterTimestamp  *prometheus.GaugeVec
+	CertRequestNotBeforeTimestamp *prometheus.GaugeVec
+	AwsCertExpirySeconds          *prometheus.GaugeVec
+	ConfigMapExpirySeconds        *prometheus.GaugeVec
+	ConfigMapNotAfterTimestamp    *prometheus.GaugeVec
+	ConfigMapNotBeforeTimestamp   *prometheus.GaugeVec
+	WebhookExpirySeconds          *prometheus.GaugeVec
+	WebhookNotAfterTimestamp      *prometheus.GaugeVec
+	WebhookNotBeforeTimestamp     *prometheus.GaugeVec
+
+	// BuildInfo is a prometheus gauge that shows build information about the cert-exporter
+	BuildInfo = versioncollector.NewCollector("cert_exporter")
+)
+
+func withSerial(labels []string) []string {
+	if serialLabelEnabled {
+		out := make([]string, len(labels)+1)
+		copy(out, labels)
+		out[len(labels)] = "serial"
+		return out
+	}
+	return labels
+}
+
+// Init registers metrics. includeSerialLabel controls whether certificate
+// gauges expose a serial label (off by default for Prometheus series
+// compatibility; enable for multi-cert keys that share cn/issuer).
+func Init(prometheusExporterMetricsDisabled bool, registry *prometheus.Registry, includeSerialLabel bool) {
+	serialLabelEnabled = includeSerialLabel
+
 	CertExpirySeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "cert_expires_in_seconds",
 			Help:      "Number of seconds til the cert expires.",
 		},
-		[]string{"filename", "issuer", "cn", "nodename"},
+		withSerial([]string{"filename", "issuer", "cn", "nodename"}),
 	)
-
-	// CertNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
 	CertNotAfterTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "cert_not_after_timestamp",
 			Help:      "Timestamp of when the certificate expires.",
 		},
-		[]string{"filename", "issuer", "cn", "nodename"},
+		withSerial([]string{"filename", "issuer", "cn", "nodename"}),
 	)
-
-	// CertNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
 	CertNotBeforeTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "cert_not_before_timestamp",
 			Help:      "Timestamp of when the certificate becomes valid.",
 		},
-		[]string{"filename", "issuer", "cn", "nodename"},
+		withSerial([]string{"filename", "issuer", "cn", "nodename"}),
 	)
 
-	// KubeConfigExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubeconfig certificate expires.
 	KubeConfigExpirySeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "kubeconfig_expires_in_seconds",
 			Help:      "Number of seconds til the cert in the kubeconfig expires.",
 		},
-		[]string{"filename", "type", "cn", "issuer", "name", "nodename"},
+		withSerial([]string{"filename", "type", "cn", "issuer", "name", "nodename"}),
 	)
-
-	// KubeConfigNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
 	KubeConfigNotAfterTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "kubeconfig_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the kubeconfig.",
 		},
-		[]string{"filename", "type", "cn", "issuer", "name", "nodename"},
+		withSerial([]string{"filename", "type", "cn", "issuer", "name", "nodename"}),
 	)
-
-	// KubeConfigNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
 	KubeConfigNotBeforeTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "kubeconfig_not_before_timestamp",
 			Help:      "Activation timestamp for cert in the kubeconfig.",
 		},
-		[]string{"filename", "type", "cn", "issuer", "name", "nodename"},
+		withSerial([]string{"filename", "type", "cn", "issuer", "name", "nodename"}),
 	)
 
-	// SecretExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubernetes secret certificate expires
 	SecretExpirySeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "secret_expires_in_seconds",
 			Help:      "Number of seconds til the cert in the secret expires.",
 		},
-		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
+		withSerial([]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"}),
 	)
-
-	// SecretNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
 	SecretNotAfterTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "secret_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the secret.",
 		},
-		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
+		withSerial([]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"}),
 	)
-
-	// SecretNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
 	SecretNotBeforeTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "secret_not_before_timestamp",
 			Help:      "Activation timestamp for cert in the secret.",
 		},
-		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
+		withSerial([]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"}),
 	)
 
-	// CertRequestExpirySeconds is a prometheus gauge that indicates the number of seconds until a certificate in a cert-manager certificate request  expires
 	CertRequestExpirySeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "certrequest_expires_in_seconds",
 			Help:      "Number of seconds til the cert in the certrequest expires.",
 		},
-		[]string{"issuer", "cn", "cert_request", "certrequest_namespace"},
+		withSerial([]string{"issuer", "cn", "cert_request", "certrequest_namespace"}),
 	)
-
-	// CertRequestNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
 	CertRequestNotAfterTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "certrequest_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the certrequest.",
 		},
-		[]string{"issuer", "cn", "cert_request", "certrequest_namespace"},
+		withSerial([]string{"issuer", "cn", "cert_request", "certrequest_namespace"}),
 	)
-
-	// CertRequestNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
 	CertRequestNotBeforeTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "certrequest_not_before_timestamp",
 			Help:      "Activation timestamp for cert in the certrequest.",
 		},
-		[]string{"issuer", "cn", "cert_request", "certrequest_namespace"},
+		withSerial([]string{"issuer", "cn", "cert_request", "certrequest_namespace"}),
 	)
 
-	// AwsCertExpirySeconds is a prometheus gauge that indicates the number of seconds until certificates on AWS expires.
 	AwsCertExpirySeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "cert_expires_in_seconds_aws",
 			Help:      "Number of seconds til the cert expires.",
 		},
-		[]string{"secretName", "key", "file", "issuer", "cn"},
+		withSerial([]string{"secretName", "key", "file", "issuer", "cn"}),
 	)
 
-	// ConfigMapExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubernetes configmap certificate expires
 	ConfigMapExpirySeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "configmap_expires_in_seconds",
 			Help:      "Number of seconds til the cert in the configmap expires.",
 		},
-		[]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"},
+		withSerial([]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"}),
 	)
-
-	// ConfigMapNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
 	ConfigMapNotAfterTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "configmap_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the configmap.",
 		},
-		[]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"},
+		withSerial([]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"}),
 	)
-
-	// ConfigMapNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
 	ConfigMapNotBeforeTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "configmap_not_before_timestamp",
 			Help:      "Activation timestamp for cert in the configmap.",
 		},
-		[]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"},
+		withSerial([]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"}),
 	)
 
-	// WebhookExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubernetes webhook certificate expires
 	WebhookExpirySeconds = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "webhook_expires_in_seconds",
 			Help:      "Number of seconds til the cert in the webhook expires.",
 		},
-		[]string{"type_name", "issuer", "cn", "webhook_name", "admission_review_version_name"},
+		withSerial([]string{"type_name", "issuer", "cn", "webhook_name", "admission_review_version_name"}),
 	)
-
-	// WebhookNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
 	WebhookNotAfterTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "webhook_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the webhook.",
 		},
-		[]string{"type_name", "issuer", "cn", "webhook_name", "admission_review_version_name"},
+		withSerial([]string{"type_name", "issuer", "cn", "webhook_name", "admission_review_version_name"}),
 	)
-
-	// WebhookNotBeforeTimestamp is a prometheus gauge that indicates the NotBefore timestamp.
 	WebhookNotBeforeTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "webhook_not_before_timestamp",
 			Help:      "Activation timestamp for cert in the webhook.",
 		},
-		[]string{"type_name", "issuer", "cn", "webhook_name", "admission_review_version_name"},
+		withSerial([]string{"type_name", "issuer", "cn", "webhook_name", "admission_review_version_name"}),
 	)
 
-	// BuildInfo is a prometheus gauge that shows build information about the cert-exporter 
-	BuildInfo = versioncollector.NewCollector("cert_exporter")
-)
-
-func Init(prometheusExporterMetricsDisabled bool, registry *prometheus.Registry) {
 	var registerer prometheus.Registerer
 
 	if registry != nil {

--- a/src/metrics/metrics_test.go
+++ b/src/metrics/metrics_test.go
@@ -1,9 +1,9 @@
 package metrics
 
 import (
-	"testing"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"testing"
 )
 
 func TestInit_WithDefaultRegistry(t *testing.T) {
@@ -11,7 +11,7 @@ func TestInit_WithDefaultRegistry(t *testing.T) {
 	testRegistry := prometheus.NewRegistry()
 
 	// Call Init with a custom registry
-	Init(false, testRegistry)
+	Init(false, testRegistry, false)
 
 	// Verify that metrics were registered by checking the gatherer
 	metricFamilies, err := testRegistry.Gather()
@@ -49,7 +49,7 @@ func TestInit_WithEmptyRegistry(t *testing.T) {
 
 	// Call Init with prometheusExporterMetricsDisabled=true and nil registry
 	// This should create an empty registry and set it as the default
-	Init(true, nil)
+	Init(true, nil, false)
 
 	// Verify that a new empty registry was created
 	// The default registerer should now be an empty registry
@@ -84,30 +84,33 @@ func TestMetricsNamespace(t *testing.T) {
 
 func TestMetricsDefinitions(t *testing.T) {
 	// Test that all metric variables are defined and not nil
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	metrics := map[string]interface{}{
-		"BuildInfo":                       BuildInfo,
-        "Discovered":                      Discovered,
-    	"ErrorTotal":                      ErrorTotal,
-		"CertExpirySeconds":               CertExpirySeconds,
-		"CertNotAfterTimestamp":           CertNotAfterTimestamp,
-		"CertNotBeforeTimestamp":          CertNotBeforeTimestamp,
-		"KubeConfigExpirySeconds":         KubeConfigExpirySeconds,
-		"KubeConfigNotAfterTimestamp":     KubeConfigNotAfterTimestamp,
-		"KubeConfigNotBeforeTimestamp":    KubeConfigNotBeforeTimestamp,
-		"SecretExpirySeconds":             SecretExpirySeconds,
-		"SecretNotAfterTimestamp":         SecretNotAfterTimestamp,
-		"SecretNotBeforeTimestamp":        SecretNotBeforeTimestamp,
-		"CertRequestExpirySeconds":        CertRequestExpirySeconds,
-		"CertRequestNotAfterTimestamp":    CertRequestNotAfterTimestamp,
-		"CertRequestNotBeforeTimestamp":   CertRequestNotBeforeTimestamp,
-		"AwsCertExpirySeconds":            AwsCertExpirySeconds,
-		"ConfigMapExpirySeconds":          ConfigMapExpirySeconds,
-		"ConfigMapNotAfterTimestamp":      ConfigMapNotAfterTimestamp,
-		"ConfigMapNotBeforeTimestamp":     ConfigMapNotBeforeTimestamp,
-		"WebhookExpirySeconds":            WebhookExpirySeconds,
-		"WebhookNotAfterTimestamp":        WebhookNotAfterTimestamp,
-		"WebhookNotBeforeTimestamp":       WebhookNotBeforeTimestamp,
-  }
+		"BuildInfo":                     BuildInfo,
+		"Discovered":                    Discovered,
+		"ErrorTotal":                    ErrorTotal,
+		"CertExpirySeconds":             CertExpirySeconds,
+		"CertNotAfterTimestamp":         CertNotAfterTimestamp,
+		"CertNotBeforeTimestamp":        CertNotBeforeTimestamp,
+		"KubeConfigExpirySeconds":       KubeConfigExpirySeconds,
+		"KubeConfigNotAfterTimestamp":   KubeConfigNotAfterTimestamp,
+		"KubeConfigNotBeforeTimestamp":  KubeConfigNotBeforeTimestamp,
+		"SecretExpirySeconds":           SecretExpirySeconds,
+		"SecretNotAfterTimestamp":       SecretNotAfterTimestamp,
+		"SecretNotBeforeTimestamp":      SecretNotBeforeTimestamp,
+		"CertRequestExpirySeconds":      CertRequestExpirySeconds,
+		"CertRequestNotAfterTimestamp":  CertRequestNotAfterTimestamp,
+		"CertRequestNotBeforeTimestamp": CertRequestNotBeforeTimestamp,
+		"AwsCertExpirySeconds":          AwsCertExpirySeconds,
+		"ConfigMapExpirySeconds":        ConfigMapExpirySeconds,
+		"ConfigMapNotAfterTimestamp":    ConfigMapNotAfterTimestamp,
+		"ConfigMapNotBeforeTimestamp":   ConfigMapNotBeforeTimestamp,
+		"WebhookExpirySeconds":          WebhookExpirySeconds,
+		"WebhookNotAfterTimestamp":      WebhookNotAfterTimestamp,
+		"WebhookNotBeforeTimestamp":     WebhookNotBeforeTimestamp,
+	}
 
 	for name, metric := range metrics {
 		if metric == nil {
@@ -118,6 +121,9 @@ func TestMetricsDefinitions(t *testing.T) {
 
 func TestCertExpirySecondsLabels(t *testing.T) {
 	// Test that CertExpirySeconds has the correct labels
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"filename": "test.crt",
 		"issuer":   "Test CA",
@@ -136,6 +142,9 @@ func TestCertExpirySecondsLabels(t *testing.T) {
 }
 
 func TestCertNotAfterTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"filename": "test.crt",
 		"issuer":   "Test CA",
@@ -151,6 +160,9 @@ func TestCertNotAfterTimestampLabels(t *testing.T) {
 }
 
 func TestCertNotBeforeTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"filename": "test.crt",
 		"issuer":   "Test CA",
@@ -166,6 +178,9 @@ func TestCertNotBeforeTimestampLabels(t *testing.T) {
 }
 
 func TestKubeConfigExpirySecondsLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"filename": "kubeconfig.yaml",
 		"type":     "client",
@@ -183,6 +198,9 @@ func TestKubeConfigExpirySecondsLabels(t *testing.T) {
 }
 
 func TestKubeConfigNotAfterTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"filename": "kubeconfig.yaml",
 		"type":     "client",
@@ -200,6 +218,9 @@ func TestKubeConfigNotAfterTimestampLabels(t *testing.T) {
 }
 
 func TestKubeConfigNotBeforeTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"filename": "kubeconfig.yaml",
 		"type":     "client",
@@ -217,6 +238,9 @@ func TestKubeConfigNotBeforeTimestampLabels(t *testing.T) {
 }
 
 func TestSecretExpirySecondsLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"key_name":         "tls.crt",
 		"issuer":           "Test CA",
@@ -233,6 +257,9 @@ func TestSecretExpirySecondsLabels(t *testing.T) {
 }
 
 func TestSecretNotAfterTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"key_name":         "tls.crt",
 		"issuer":           "Test CA",
@@ -249,6 +276,9 @@ func TestSecretNotAfterTimestampLabels(t *testing.T) {
 }
 
 func TestSecretNotBeforeTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"key_name":         "tls.crt",
 		"issuer":           "Test CA",
@@ -265,6 +295,9 @@ func TestSecretNotBeforeTimestampLabels(t *testing.T) {
 }
 
 func TestCertRequestExpirySecondsLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"issuer":                "letsencrypt",
 		"cn":                    "test.example.com",
@@ -280,6 +313,9 @@ func TestCertRequestExpirySecondsLabels(t *testing.T) {
 }
 
 func TestCertRequestNotAfterTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"issuer":                "letsencrypt",
 		"cn":                    "test.example.com",
@@ -295,6 +331,9 @@ func TestCertRequestNotAfterTimestampLabels(t *testing.T) {
 }
 
 func TestCertRequestNotBeforeTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"issuer":                "letsencrypt",
 		"cn":                    "test.example.com",
@@ -310,6 +349,9 @@ func TestCertRequestNotBeforeTimestampLabels(t *testing.T) {
 }
 
 func TestAwsCertExpirySecondsLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"secretName": "aws-secret",
 		"key":        "certificate.pem",
@@ -326,6 +368,9 @@ func TestAwsCertExpirySecondsLabels(t *testing.T) {
 }
 
 func TestConfigMapExpirySecondsLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"key_name":            "ca.crt",
 		"issuer":              "Test CA",
@@ -342,6 +387,9 @@ func TestConfigMapExpirySecondsLabels(t *testing.T) {
 }
 
 func TestConfigMapNotAfterTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"key_name":            "ca.crt",
 		"issuer":              "Test CA",
@@ -358,6 +406,9 @@ func TestConfigMapNotAfterTimestampLabels(t *testing.T) {
 }
 
 func TestConfigMapNotBeforeTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"key_name":            "ca.crt",
 		"issuer":              "Test CA",
@@ -374,6 +425,9 @@ func TestConfigMapNotBeforeTimestampLabels(t *testing.T) {
 }
 
 func TestWebhookExpirySecondsLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"type_name":                     "validating",
 		"issuer":                        "webhook-ca",
@@ -390,6 +444,9 @@ func TestWebhookExpirySecondsLabels(t *testing.T) {
 }
 
 func TestWebhookNotAfterTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"type_name":                     "validating",
 		"issuer":                        "webhook-ca",
@@ -406,6 +463,9 @@ func TestWebhookNotAfterTimestampLabels(t *testing.T) {
 }
 
 func TestWebhookNotBeforeTimestampLabels(t *testing.T) {
+	testRegistry := prometheus.NewRegistry()
+	Init(true, testRegistry, false)
+
 	labels := prometheus.Labels{
 		"type_name":                     "validating",
 		"issuer":                        "webhook-ca",
@@ -423,7 +483,7 @@ func TestWebhookNotBeforeTimestampLabels(t *testing.T) {
 
 func TestBuildInfo(t *testing.T) {
 	collector := BuildInfo
-	
+
 	// Collect build_info metric from the channel
 	ch := make(chan prometheus.Metric, 1)
 	collector.Collect(ch)
@@ -441,7 +501,7 @@ func TestBuildInfo(t *testing.T) {
 		actualLabels[lp.GetName()] = lp.GetValue()
 	}
 	t.Log("------------------------------------")
-	
+
 	// Define expected labels (common build_info labels)
 	expectedLabels := []string{
 		"version",
@@ -461,7 +521,6 @@ func TestBuildInfo(t *testing.T) {
 	}
 }
 
-
 func TestErrorTotalCounter(t *testing.T) {
 	// Test that ErrorTotal counter can be incremented
 	// Note: We can't easily verify the actual value due to global state,
@@ -478,4 +537,26 @@ func TestDiscoveredGauge(t *testing.T) {
 	Discovered.Dec()
 	Discovered.Add(5)
 	Discovered.Sub(3)
+}
+
+func TestSerialLabelFlag(t *testing.T) {
+	regOn := prometheus.NewRegistry()
+	Init(true, regOn, true)
+	if !SerialLabelEnabled() {
+		t.Fatal("expected serial number label enabled")
+	}
+	on := CertExpirySeconds.With(prometheus.Labels{
+		"filename": "t.crt", "issuer": "ca", "cn": "cn", "nodename": "n", "serial": "ab",
+	})
+	on.Set(1)
+
+	regOff := prometheus.NewRegistry()
+	Init(true, regOff, false)
+	if SerialLabelEnabled() {
+		t.Fatal("expected serial number label disabled")
+	}
+	off := CertExpirySeconds.With(prometheus.Labels{
+		"filename": "t.crt", "issuer": "ca", "cn": "cn", "nodename": "n",
+	})
+	off.Set(1)
 }

--- a/test/files/test.sh
+++ b/test/files/test.sh
@@ -57,12 +57,25 @@ assertMetricLine() {
     exit 1
 }
 
+# Drop trailing "}" and trailing type= so serial (and other) labels
+# can appear without breaking substring matches against exposition text.
+normalizeMetricNeedle() {
+    local n="$1"
+    n="${n%\}}"
+    n="${n%,type=\"cluster\"}"
+    n="${n%,type=\"user\"}"
+    printf '%s' "$n"
+}
+
 fetchMetricsTimestampValue() {
     local metrics
+    local needle
     metrics="$1"
+    needle=$(normalizeMetricNeedle "$metrics")
 
     curl --silent http://localhost:8080/metrics \
-    | grep -F "$metrics" \
+    | grep -F "$needle" \
+    | head -n1 \
     | awk '{ printf("%.0f",$2) }' || true
 }
 
@@ -95,11 +108,13 @@ validateMetrics() {
     local raw
     local val
     local valInDays
+    local needle
     metrics=$1
     expectedVal=$2
+    needle=$(normalizeMetricNeedle "$metrics")
 
     # grep returns 1 when there is no match; do not trip set -e
-    raw=$(curl --silent http://localhost:8080/metrics | grep "$metrics" || true)
+    raw=$(curl --silent http://localhost:8080/metrics | grep -F "$needle" | head -n1 || true)
 
     if [ "$raw" == "" ]; then
       echo "TEST FAILURE: $metrics" 


### PR DESCRIPTION
Fixes #244 

**BREAKING CHANGE**: It is gated by a feature flag, `--include-serial-label`. 

Add a `serial` label to certificate metrics so multiple PEMs that share `cn`/`issuer` label values (e.g. rotated CA bundles) appear as distinct series. 

Depending on how many certificates you monitor, this could be a lot of new series all at once, hence the decision to put it behind a feature flag. 